### PR TITLE
Build Docker image in stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM rustlang/rust:nightly-slim
+FROM rustlang/rust:nightly-slim AS build
 
 WORKDIR /usr/src/sonic
 
 RUN apt-get update
 RUN apt-get install -y build-essential clang
 RUN cargo install sonic-server
+
+FROM debian:stretch-slim
+
+COPY --from=build /usr/local/cargo/bin/sonic /usr/local/bin/sonic
+
 CMD [ "sonic", "-c", "/etc/sonic.cfg" ]
 
 EXPOSE 1491


### PR DESCRIPTION
As per the discussion in #72 I separated the Docker build into two stages. The resulting image is based on `debian:stretch-slim` (the same base image that `rustlang/rust:nightly-slim` uses) and comes in at `68.5MB`. It seems to work for me locally. 👍 