### PR TITLE
doc() added precision on using password (tcp)

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -24,7 +24,7 @@ _Refer to sections below to interact with Sonic Channel._
 
 ### 2️⃣ Sonic Channel (uninitialized)
 
-* `START <mode>`: select mode to use for connection (either: `search` or `ingest`)
+* `START <mode> <password>`: select mode to use for connection (either: `search` or `ingest`). The password is found in the `config.cfg` file at `channel.auth_password`.
 
 _Issuing any other command — eg. `QUIT` — in this mode will abort the TCP connection, effectively resulting in a `QUIT` with the `ENDED not_recognized` response._
 


### PR DESCRIPTION
The indication was missing in the documentation.