### PR TITLE
Use jemalloc as global allocator only on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-jemallocator = { version = "0.3", optional = true }
 log = "0.4"
 toml = "0.5"
 clap = { version = "2.33", default-features = false }
@@ -45,6 +44,7 @@ regex = "1.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.14"
+jemallocator = { version = "0.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "consoleapi"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ extern crate whatlang;
 #[cfg(windows)]
 extern crate winapi;
 
+#[cfg(unix)]
 #[cfg(feature = "alloc-jemalloc")]
 extern crate jemallocator;
 
@@ -68,6 +69,7 @@ struct AppArgs {
     config: String,
 }
 
+#[cfg(unix)]
 #[cfg(feature = "alloc-jemalloc")]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;


### PR DESCRIPTION
#161 
jemallocator has no supoort for window-msvc now [jemallocator #91](https://github.com/gnzlbg/jemallocator/issues/91), use it as global allocator only on unix