### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Sonic supports a wide range of languages in its lexing system. If a language is 
 * 🇨🇿 Czech
 * 🇩🇰 Danish
 * 🇳🇱 Dutch
-* 🇺🇸 English
+* 🇬🇧 English
 * 🏳 Esperanto
 * 🇪🇪 Estonian
 * 🇫🇮 Finnish


### PR DESCRIPTION
* Changed the flag for 'English' to one which more appropriate. English came from England, in Britain, hence the Union Flag. If this gets rejected, I will just open a PR changing 'French' to the Canadian flag. Same argument.