### PR TITLE
channel: fix possible concurrency bugs in ChannelMessage::on

### DIFF
--- a/src/channel/message.rs
+++ b/src/channel/message.rs
@@ -125,14 +125,17 @@ impl ChannelMessage {
             //   commands that do no work or I/O; they would make statistics less accurate)
             let command_took_millis = command_took.as_millis() as u32;
 
-            if command_took_millis > *COMMAND_LATENCY_WORST.read().unwrap() {
-                *COMMAND_LATENCY_WORST.write().unwrap() = command_took_millis;
-            }
-            if command_took_millis > 0
-                && (*COMMAND_LATENCY_BEST.read().unwrap() == 0
-                    || command_took_millis < *COMMAND_LATENCY_BEST.read().unwrap())
             {
-                *COMMAND_LATENCY_BEST.write().unwrap() = command_took_millis;
+                let mut worst = COMMAND_LATENCY_WORST.write().unwrap();
+                if command_took_millis > *worst {
+                    *worst = command_took_millis;
+                }
+            }
+            {
+                let mut best = COMMAND_LATENCY_BEST.write().unwrap();
+                if command_took_millis > 0 && (*best == 0 || command_took_millis < *best) {
+                    *best = command_took_millis;
+                }
             }
 
             // Increment total commands


### PR DESCRIPTION
There are possibly two kinds of bugs in `ChannelMessage::on` if it is called by two threads simultaneously:
1. Deadlock:  
https://github.com/valeriansaliou/sonic/blob/ac7bcf118e9989f433b69a81cae8d815225139a0/src/channel/message.rs#L131-L136
There are two RwLock::read() on L132 and L133. The first read lock is not released before the second lock. A deadlock may happen when the two read locks are interleaved by a write lock from another thread. The reason is that the priority policy of `std::sync::RwLock` is [dependent on the underlying operating system's implementation](https://doc.rust-lang.org/std/sync/struct.RwLock.html). AFAIK, [Windows and macOS use fair policy](https://www.reddit.com/r/rust/comments/f4zldz/i_audited_3_different_implementation_of_async/) which leads to this kind of deadlock.
2. Atomicity Violation:
Here, write is dependent on the result of read. If they are interleaved by another write from another thread, then atomicity violation may happen. There are two cases of this kind of bug. We'd better put read&write in one critical section.

The patch uses only one write lock for each case. So the deadlock&atomicity violation bugs are fixed. I wrap the cases with `{ }` to keep the original semantics.