### PR TITLE
store: fix deadlock caused by conflicting lock order

### DIFF
--- a/src/store/fst.rs
+++ b/src/store/fst.rs
@@ -197,10 +197,11 @@ impl StoreFSTPool {
             // Notice: this prevents store to be acquired from any context
             let _access = GRAPH_ACCESS_LOCK.write().unwrap();
 
+            let graph_pool_read = GRAPH_POOL.read().unwrap();
             let graph_consolidate_read = GRAPH_CONSOLIDATE.read().unwrap();
 
             for key in &*graph_consolidate_read {
-                if let Some(store) = GRAPH_POOL.read().unwrap().get(&key) {
+                if let Some(store) = graph_pool_read.get(&key) {
                     let not_consolidated_for = store
                         .last_consolidated
                         .read()


### PR DESCRIPTION
`GRAPH_POOL` is locked before `GRAPH_CONSOLIDATE` at L102 and L103, L961 and L961
https://github.com/valeriansaliou/sonic/blob/fd7a21b9983228f76ad6f08560464d08a15c429e/src/store/fst.rs#L102-L103
https://github.com/valeriansaliou/sonic/blob/fd7a21b9983228f76ad6f08560464d08a15c429e/src/store/fst.rs#L960-L961
However, their lock order reverses at L200 and L203. https://github.com/valeriansaliou/sonic/blob/fd7a21b9983228f76ad6f08560464d08a15c429e/src/store/fst.rs#L200-L203
This may cause a deadlock:
|Thread-A|Thread-B|
|---|---|
|A.lock()||
||B.lock()|
|B.lock()//deadlock!||
||A.lock()//deadlock!|

The patch is to enforce the order for the two locks.
