### PR TITLE
chore: add rust sonic-channel client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ You can find below a list of Sonic integrations provided by the community (many 
 
 * **Rust**:
   * **[sonic_client](https://github.com/FrontMage/sonic_client)** by [@FrontMage](https://github.com/FrontMage)
+  * **[sonic-channel](https://github.com/pleshevskiy/sonic-channel)** by [@pleshevskiy](https://github.com/pleshevskiy)
 * **Python**:
   * **[asonic](https://github.com/moshe/asonic)** by [@moshe](https://github.com/moshe)
   * **[python-sonic-client](https://github.com/xmonader/python-sonic-client)** by [@xmonader](https://github.com/xmonader)


### PR DESCRIPTION
Hello!

I started to make rust library for sonic client because rust version from frostmage seems deprecated or unsupported.