### PR TITLE
Use tikv-jemallocator instead of jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,27 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jieba-rs"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,7 +564,6 @@ dependencies = [
  "fst-levenshtein",
  "fst-regex",
  "hashbrown 0.11.2",
- "jemallocator",
  "jieba-rs",
  "lazy_static",
  "linked_hash_set",
@@ -598,6 +576,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_derive",
+ "tikv-jemallocator",
  "toml",
  "twox-hash",
  "unicode-segmentation",
@@ -635,6 +614,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.2+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,14 @@ regex = "1.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.18"
-jemallocator = { version = "0.3", optional = true }
+tikv-jemallocator = { version = "0.4.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "consoleapi"] }
 
 [features]
 default = ["allocator-jemalloc", "tokenizer-chinese"]
-allocator-jemalloc = ["jemallocator"]
+allocator-jemalloc = ["tikv-jemallocator"]
 tokenizer-chinese = ["jieba-rs"]
 benchmark = []
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct AppArgs {
 #[cfg(unix)]
 #[cfg(feature = "allocator-jemalloc")]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub static LINE_FEED: &str = "\r\n";
 


### PR DESCRIPTION
`jemallocator` has been abandoned for two years. And `rustc` itself moved to use `tikv-jemallocator` instead: https://github.com/rust-lang/rust/commit/3965773ae7743e051070b4eed3c6e02e9df3b25c

Let's switch to a better maintained version.