### PR TITLE
Use distroless instead of debian slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app
 RUN cargo clean && cargo build --release --target x86_64-unknown-linux-gnu
 RUN strip ./target/x86_64-unknown-linux-gnu/release/sonic
 
-FROM debian:bullseye-slim
+FROM gcr.io/distroless/cc
 
 WORKDIR /usr/src/sonic
 


### PR DESCRIPTION
Use distroless to build docker image. It is more secure and reduces the image size from ~98MB to ~39MB.