### PR TITLE
Add basic nix flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,17 @@
+name: nix
+
+on: [pull_request, push]
+
+jobs:
+  nix-flake:
+    name: Nix packaging (flake)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+      - name: Flake check
+        run: nix flake check --no-update-lock-file --show-trace --verbose
+      - name: Flake build
+        run: nix build --no-update-lock-file --show-trace --verbose --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 target/*
 .DS_Store
 *~
@@ -6,3 +7,7 @@ target/*
 
 data/store/fst/*
 data/store/kv/*
+
+# direnv
+.envrc
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666244578,
+        "narHash": "sha256-OO0F2b83isMVHYtcvxiExig28zPE7Weo7r1fHtQTZzU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "260eb420a2e55e3a0411e731b933c3a8bf6b778e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      inherit (builtins) fromTOML readFile substring;
+
+      cargoToml = fromTOML (readFile ./Cargo.toml);
+      version = "${cargoToml.package.version}+${substring 0 8 self.lastModifiedDate}_${self.shortRev or "dirty"}";
+
+      mkSonicServer = { lib, rustPlatform, llvmPackages, clang, ... }:
+        rustPlatform.buildRustPackage {
+          pname = cargoToml.package.name;
+          inherit version;
+
+          src = lib.cleanSource ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+          # TODO: fix and enable tests
+          doCheck = false;
+
+          nativeBuildInputs = [
+            llvmPackages.libclang
+            llvmPackages.libcxxClang
+            clang
+          ];
+          # Needed so bindgen can find libclang.so
+          LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion clang}/include";
+
+          postInstall = ''
+            mkdir -p $out/share
+            cp config.cfg $out/share
+          '';
+        };
+
+    in
+    {
+      overlays.sonic-server = final: prev: {
+        sonic-server = prev.callPackage mkSonicServer { };
+      };
+      overlays.default = self.overlays.sonic-server;
+    }
+    //
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        sonic-server = pkgs.callPackage mkSonicServer { };
+      in
+      {
+        packages = {
+          inherit sonic-server;
+          default = sonic-server;
+        };
+
+        apps.sonic-server = {
+          type = "app";
+          program = "${sonic-server}/bin/sonic";
+        };
+        apps.default = self.apps.${system}.sonic-server;
+
+        devShells.default = pkgs.mkShell {
+          inherit (sonic-server) nativeBuildInputs LIBCLANG_PATH BINDGEN_EXTRA_CLANG_ARGS;
+          packages = with pkgs; [ cargo rustc rustfmt clippy rust-analyzer ];
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,9 +31,21 @@
           BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion clang}/include";
 
           postInstall = ''
-            mkdir -p $out/share
-            cp config.cfg $out/share
+            mkdir -p $out/etc/
+            mkdir -p $out/usr/lib/systemd/system/
+
+            install -Dm444 -t $out/etc/sonic config.cfg 
+            substitute \
+              ./examples/config/systemd.service $out/usr/lib/systemd/system/sonic-server.service \
+              --replace /bin/sonic $out/bin/sonic \
+              --replace /etc/sonic.cfg $out/etc/sonic/config.cfg
           '';
+
+          meta = {
+            homepage = "https://github.com/valeriansaliou/sonic";
+            downloadPage = "https://github.com/valeriansaliou/sonic/releases";
+            license = lib.licenses.mpl20;
+          };
         };
 
     in


### PR DESCRIPTION
I have added a basic flake.nix configuration for nix users, as well as CI for tests of functionality.

This will help me use the latest sonic-server and add new functionality to sonic-channel.

And in the future I would like to add a nixos module, since I am transferring the whole my infrastructure to this operating system)