### PR TITLE
Delete the flags from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,61 +190,60 @@ Sonic supports a wide range of languages in its lexing system. If a language is 
 
 **The languages supported by the lexing system are:**
 
-* 🇿🇦 Afrikaans
-* 🇸🇦 Arabic
-* 🇦🇲 Armenian
-* 🇦🇿 Azerbaijani
-* 🇧🇩 Bengali
-* 🇧🇬 Bulgarian
-* 🇲🇲 Burmese
-* 🏳 Catalan
-* 🇨🇳 Chinese (Simplified)
-* 🇹🇼 Chinese (Traditional)
-* 🇭🇷 Croatian
-* 🇨🇿 Czech
-* 🇩🇰 Danish
-* 🇳🇱 Dutch
-* 🇬🇧 English
-* 🏳 Esperanto
-* 🇪🇪 Estonian
-* 🇫🇮 Finnish
-* 🇫🇷 French
-* 🇬🇪 Georgian
-* 🇩🇪 German
-* 🇬🇷 Greek
-* 🇮🇳 Gujarati
-* 🇮🇱 Hebrew
-* 🇮🇳 Hindi
-* 🇭🇺 Hungarian
-* 🇮🇩 Indonesian
-* 🇮🇹 Italian
-* 🇯🇵 Japanese
-* 🇮🇳 Kannada
-* 🇰🇭 Khmer
-* 🇰🇷 Korean
-* 🏳 Latin
-* 🇱🇻 Latvian
-* 🇱🇹 Lithuanian
-* 🇮🇳 Marathi
-* 🇳🇵 Nepali
-* 🇮🇷 Persian
-* 🇵🇱 Polish
-* 🇵🇹 Portuguese
-* 🇮🇳 Punjabi
-* 🇷🇺 Russian
-* 🇸🇰 Slovak
-* 🇸🇮 Slovene
-* 🇪🇸 Spanish
-* 🇸🇪 Swedish
-* 🇵🇭 Tagalog
-* 🇮🇳 Tamil
-* 🇹🇭 Thai
-* 🇹🇷 Turkish
-* 🇺🇦 Ukrainian
-* 🇵🇰 Urdu
-* 🇻🇳 Vietnamese
-* 🇮🇱 Yiddish
-* 🇿🇦 Zulu
+*  Afrikaans
+*  Arabic
+*  Armenian
+*  Azerbaijani
+*  Bengali
+*  Bulgarian
+*  Burmese
+*  Catalan
+*  Chinese (Simplified and Traditional)
+*  Croatian
+*  Czech
+*  Danish
+*  Dutch
+*  English
+*  Esperanto
+*  Estonian
+*  Finnish
+*  French
+*  Georgian
+*  German
+*  Greek
+*  Gujarati
+*  Hebrew
+*  Hindi
+*  Hungarian
+*  Indonesian
+*  Italian
+*  Japanese
+*  Kannada
+*  Khmer
+*  Korean
+*  Latin
+*  Latvian
+*  Lithuanian
+*  Marathi
+*  Nepali
+*  Persian
+*  Polish
+*  Portuguese
+*  Punjabi
+*  Russian
+*  Slovak
+*  Slovene
+*  Spanish
+*  Swedish
+*  Tagalog
+*  Tamil
+*  Thai
+*  Turkish
+*  Ukrainian
+*  Urdu
+*  Vietnamese
+*  Yiddish
+*  Zulu
 
 ## How fast & lightweight is it?
 


### PR DESCRIPTION
Fix #297

If you think that the list is not fun enough, you (or I if you prefer) can just hide it with the HTML “details” tag.


<details>
<summary><strong>The list of languages supported by the lexing system</strong></summary>

*  Afrikaans
*  Arabic
*  Armenian
*  Azerbaijani
*  Bengali
*  Bulgarian
*  Burmese
*  Catalan
*  Chinese (Simplified and Traditional)
*  Croatian
*  Czech
*  Danish
*  Dutch
*  English
*  Esperanto
*  Estonian
*  Finnish
*  French
*  Georgian
*  German
*  Greek
*  Gujarati
*  Hebrew
*  Hindi
*  Hungarian
*  Indonesian
*  Italian
*  Japanese
*  Kannada
*  Khmer
*  Korean
*  Latin
*  Latvian
*  Lithuanian
*  Marathi
*  Nepali
*  Persian
*  Polish
*  Portuguese
*  Punjabi
*  Russian
*  Slovak
*  Slovene
*  Spanish
*  Swedish
*  Tagalog
*  Tamil
*  Thai
*  Turkish
*  Ukrainian
*  Urdu
*  Vietnamese
*  Yiddish
*  Zulu
</details>