### PR TITLE
Adding docker image for ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           push: true


### PR DESCRIPTION
Hey,

I would love to run this on ARM without having to build the container locally.
I added a tag that will build docker image for ARM based systems in parallel to x86. 