### PR TITLE
Bump rocksdb to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",
@@ -95,11 +95,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -685,14 +687,29 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -878,6 +895,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1055,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -1344,9 +1381,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1531,6 +1568,12 @@ name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_derive = "1.0"
 rand = "0.8"
 unicode-segmentation = "1.6"
 radix = "0.6"
-rocksdb = { version = "0.17", features = ["zstd"] }
+rocksdb = { version = "0.21", features = ["zstd"] }
 fst = "0.3"
 fst-levenshtein = "0.3"
 fst-regex = "0.3"

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -12,7 +12,7 @@ use rocksdb::backup::{
     RestoreOptions as DBRestoreOptions,
 };
 use rocksdb::{
-    DBCompactionStyle, DBCompressionType, Error as DBError, FlushOptions, Options as DBOptions,
+    DBCompactionStyle, DBCompressionType, Env as DBEnv, Error as DBError, FlushOptions, Options as DBOptions,
     WriteBatch, WriteOptions, DB,
 };
 use std::fmt;
@@ -298,8 +298,9 @@ impl StoreKVPool {
                     .map_err(|_| io_error!("database open failure"))?;
 
                 // Initialize KV database backup engine
+                let backup_opts = DBBackupEngineOptions::new(&kv_backup_path).unwrap();
                 let mut kv_backup_engine =
-                    DBBackupEngine::open(&DBBackupEngineOptions::default(), &kv_backup_path)
+                    DBBackupEngine::open(&backup_opts, &DBEnv::new().unwrap())
                         .map_err(|_| io_error!("backup engine failure"))?;
 
                 // Proceed actual KV database backup
@@ -350,8 +351,9 @@ impl StoreKVPool {
                 fs::create_dir_all(&kv_path)?;
 
                 // Initialize KV database backup engine
+                let backup_opts = DBBackupEngineOptions::new(&origin_path).unwrap();
                 let mut kv_backup_engine =
-                    DBBackupEngine::open(&DBBackupEngineOptions::default(), &origin_path)
+                    DBBackupEngine::open(&backup_opts, &DBEnv::new().unwrap())
                         .map_err(|_| io_error!("backup engine failure"))?;
 
                 kv_backup_engine


### PR DESCRIPTION
Fixes #315

Build of sonic-server is failing on NixOS for a few weeks now, see https://hydra.nixos.org/build/239524816
This failing build has been caused by a clang 16 upgrade, because rocksdb depends on a old [rust-bindgen](https://github.com/rust-lang/rust-bindgen) version which is not compatible with this version of clang, see https://github.com/rust-lang/rust-bindgen/issues/2312

A resolution is to upgrade rocksdb to its latest version.