### PR TITLE
Fix build warnings treated as errors

### DIFF
--- a/src/store/fst.rs
+++ b/src/store/fst.rs
@@ -687,7 +687,7 @@ impl StoreFSTPool {
                                 );
 
                                 // Proceed temporary FST to final FST path rename
-                                if std::fs::rename(&bucket_tmp_path, &bucket_final_path).is_ok() {
+                                if fs::rename(&bucket_tmp_path, &bucket_final_path).is_ok() {
                                     info!("done consolidate fst at path: {:?}", bucket_final_path);
                                 } else {
                                     error!(

--- a/src/store/generic.rs
+++ b/src/store/generic.rs
@@ -11,8 +11,6 @@ use std::fmt::Display;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
-pub trait StoreGenericKey {}
-
 pub trait StoreGeneric {
     fn ref_last_used(&self) -> &RwLock<SystemTime>;
 }


### PR DESCRIPTION
These warnings prevent builds on latest master with latest stable rustc 1.78.0 (9b00956e5 2024-04-29)

Full error:

```
   Compiling sonic-server v1.4.8 (/Users/j/src/sonic)
error: unnecessary qualification
   --> src/store/fst.rs:690:36
    |
690 | ...                   if std::fs::rename(&bucket_tmp_path, &bucket_final_path).is_ok() {
    |                          ^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/main.rs:8:44
    |
8   | #![deny(unstable_features, unused_imports, unused_qualifications, clippy::all)]
    |                                            ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
    |
690 -                                 if std::fs::rename(&bucket_tmp_path, &bucket_final_path).is_ok() {
690 +                                 if fs::rename(&bucket_tmp_path, &bucket_final_path).is_ok() {
    |

warning: trait `StoreGenericKey` is never used
  --> src/store/generic.rs:14:11
   |
14 | pub trait StoreGenericKey {}
   |           ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `sonic-server` (bin "sonic") generated 1 warning
error: could not compile `sonic-server` (bin "sonic") due to 1 previous error; 1 warning emitted
```