### PR TITLE
Move /etc/sonic.cfg to /run/sonic/sonic.cfg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR /usr/src/sonic
 
 COPY --from=build /app/target/release/sonic /usr/local/bin/sonic
 
+RUN ln -s /run/sonic/sonic.cfg /etc/sonic.cfg
+VOLUME /run/sonic
+
 CMD [ "sonic", "-c", "/etc/sonic.cfg" ]
 
 EXPOSE 1491


### PR DESCRIPTION
When using this container in docker-compose it is not that easy to bind mount a file into the container. It has a way better user experience when one can just specify a folder. Currently this doesn't work with the default configuration as the sonic.cfg is directly within /etc. By replacing /etc/sonic.cfg with a symlink to /run/sonic/sonic.cfg we can solve this issue and also introducing a breaking change.