### PR TITLE
Configure Clippy and run `cargo clippy --fix`

### DIFF
--- a/src/channel/macros.rs
+++ b/src/channel/macros.rs
@@ -4,7 +4,6 @@
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-#[macro_export]
 macro_rules! gen_channel_message_mode_handle {
     ($message:ident, $commands:ident, { $($external:expr => $internal:expr),+, }) => {{
         let (command, parts) = ChannelMessage::extract($message);

--- a/src/channel/message.rs
+++ b/src/channel/message.rs
@@ -49,6 +49,7 @@ impl ChannelMessage {
         let mut result = ChannelMessageResult::Continue;
 
         // Process response for issued command
+        #[allow(clippy::needless_late_init)]
         let response_args_groups: Vec<ChannelCommandResponseArgs>;
 
         if !(*CHANNEL_AVAILABLE.read().unwrap()) {

--- a/src/executor/macros.rs
+++ b/src/executor/macros.rs
@@ -4,7 +4,6 @@
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-#[macro_export]
 macro_rules! executor_ensure_op {
     ($operation:expr) => {
         match $operation {
@@ -14,7 +13,6 @@ macro_rules! executor_ensure_op {
     };
 }
 
-#[macro_export]
 macro_rules! executor_kv_lock_read {
     ($store:ident) => {
         let kv_store_reference = $store.clone();
@@ -25,7 +23,6 @@ macro_rules! executor_kv_lock_read {
     };
 }
 
-#[macro_export]
 macro_rules! executor_kv_lock_write {
     ($store:ident) => {
         let kv_store_reference = $store.clone();
@@ -36,7 +33,6 @@ macro_rules! executor_kv_lock_write {
     };
 }
 
-#[macro_export]
 macro_rules! general_kv_access_lock_read {
     () => {
         use crate::store::kv::STORE_ACCESS_LOCK;
@@ -45,7 +41,6 @@ macro_rules! general_kv_access_lock_read {
     };
 }
 
-#[macro_export]
 macro_rules! general_kv_access_lock_write {
     () => {
         use crate::store::kv::STORE_ACCESS_LOCK;
@@ -54,7 +49,6 @@ macro_rules! general_kv_access_lock_write {
     };
 }
 
-#[macro_export]
 macro_rules! general_fst_access_lock_read {
     () => {
         use crate::store::fst::GRAPH_ACCESS_LOCK;
@@ -63,7 +57,6 @@ macro_rules! general_fst_access_lock_read {
     };
 }
 
-#[macro_export]
 macro_rules! general_fst_access_lock_write {
     () => {
         use crate::store::fst::GRAPH_ACCESS_LOCK;

--- a/src/executor/pop.rs
+++ b/src/executor/pop.rs
@@ -124,7 +124,7 @@ impl ExecutorPop {
 
                                     // Bump IID-to-Terms list
                                     let remaining_terms_vec: Vec<StoreTermHashed> =
-                                        Vec::from_iter(remaining_terms.into_iter());
+                                        Vec::from_iter(remaining_terms);
 
                                     executor_ensure_op!(
                                         kv_action.set_iid_to_terms(iid, &remaining_terms_vec)

--- a/src/executor/search.rs
+++ b/src/executor/search.rs
@@ -52,8 +52,7 @@ impl ExecutorSearch {
                         kv_action
                             .get_term_to_iids(term_hashed)
                             .unwrap_or(None)
-                            .unwrap_or_default()
-                            .into_iter(),
+                            .unwrap_or_default(),
                     );
 
                     // No IIDs? Try to complete with a suggested alternate word

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,16 @@
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-#![cfg_attr(feature = "benchmark", feature(test))]
 #![deny(unstable_features, unused_imports, unused_qualifications, clippy::all)]
+#![warn(
+    clippy::inline_always, // Do not use unless benchmarked (explicit allow).
+)]
+#![allow(
+    clippy::explicit_auto_deref, // Style preference.
+    clippy::needless_as_bytes, // Style preference. Better make those things explicit.
+    clippy::needless_borrow, // Style preference.
+    clippy::needless_borrows_for_generic_args, // Style preference.
+)]
 
 #[macro_use]
 extern crate log;

--- a/src/store/fst.rs
+++ b/src/store/fst.rs
@@ -319,6 +319,7 @@ impl StoreFSTPool {
         );
     }
 
+    #[allow(clippy::type_complexity)]
     fn dump_action(
         action: &str,
         path_mode: StoreFSTPathMode,
@@ -527,7 +528,7 @@ impl StoreFSTPool {
         // Do consolidate? (any change committed)
         // Notice: if both pending sets are empty do not consolidate as there may have been a \
         //   push then a pop of this push, nulling out any committed change.
-        if pending_push_write.len() > 0 || pending_pop_write.len() > 0 {
+        if !(pending_push_write.is_empty() && pending_pop_write.is_empty()) {
             // Read old FST (or default to empty FST)
             if let Ok(old_fst) =
                 StoreFSTBuilder::open(store.target.collection_hash, store.target.bucket_hash)
@@ -868,9 +869,9 @@ impl StoreFST {
     ) -> Result<FSTStream<'_, Levenshtein>, ()> {
         // Allow more typos in word as the word gets longer, up to a maximum limit
         let mut typo_factor = match word.len() {
-            1 | 2 | 3 => 0,
-            4 | 5 | 6 => 1,
-            7 | 8 | 9 => 2,
+            1..=3 => 0,
+            4..=6 => 1,
+            7..=9 => 2,
             _ => 3,
         };
 

--- a/src/store/item.rs
+++ b/src/store/item.rs
@@ -32,10 +32,7 @@ impl<'a> StoreItemPart<'a> {
     pub fn from_str(part: &'a str) -> Result<Self, ()> {
         let len = part.len();
 
-        if len > STORE_ITEM_PART_LEN_MIN
-            && len <= STORE_ITEM_PART_LEN_MAX
-            && part.chars().all(|character| character.is_ascii())
-        {
+        if len > STORE_ITEM_PART_LEN_MIN && len <= STORE_ITEM_PART_LEN_MAX && part.is_ascii() {
             Ok(StoreItemPart(part))
         } else {
             Err(())

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -1044,7 +1044,7 @@ impl<'a> StoreKVAction<'a> {
             let (k_meta_to_value, k_term_to_iids, k_oid_to_iid, k_iid_to_oid, k_iid_to_terms) = (
                 StoreKeyerBuilder::meta_to_value(self.bucket.as_str(), &StoreMetaKey::IIDIncr),
                 StoreKeyerBuilder::term_to_iids(self.bucket.as_str(), 0),
-                StoreKeyerBuilder::oid_to_iid(self.bucket.as_str(), &String::new()),
+                StoreKeyerBuilder::oid_to_iid(self.bucket.as_str(), ""),
                 StoreKeyerBuilder::iid_to_oid(self.bucket.as_str(), 0),
                 StoreKeyerBuilder::iid_to_terms(self.bucket.as_str(), 0),
             );

--- a/src/store/macros.rs
+++ b/src/store/macros.rs
@@ -4,7 +4,6 @@
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-#[macro_export]
 macro_rules! io_error {
     ($error:expr) => {
         io::Error::new(io::ErrorKind::Other, $error)

--- a/src/store/operation.rs
+++ b/src/store/operation.rs
@@ -32,7 +32,7 @@ impl StoreOperationDispatch {
             Query::List(store, query_id, limit, offset) => {
                 ExecutorList::execute(store, query_id, limit, offset)
                     .map(|results| results.join(" "))
-                    .map(|results| Some(results))
+                    .map(Some)
             }
             Query::Push(store, lexer) => ExecutorPush::execute(store, lexer).map(|_| None),
             Query::Pop(store, lexer) => {


### PR DESCRIPTION
I also removed useless `#[macro_export]`s first as they would trigger [`clippy::crate_in_macro_def`](https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html?search=macro#crate_in_macro_def).