### PR TITLE
config: Support environment-based configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,20 +1,34 @@
 # Sonic Configuration
 
-## File: config.cfg
+## Configuration sources
+
+Sonic looks for its configuration as [TOML] in `./config.cfg`, or whatever you
+passed via `--config`/`-c`.
+
+This file is optional, as all configuration keys can be defined using
+`SONIC_` environment variables (which take precedence over the static
+configuration). The path separator is `__`, which means `foo.bar.baz` will be
+read from `SONIC_FOO__BAR__BAZ`.
+
+## Configuration keys reference
 
 **All available configuration options are commented below, with allowed values:**
 
-**[server]**
+### Server configuration
+
+Under `[server]`:
 
 * `log_level` (type: _string_, allowed: `debug`, `info`, `warn`, `error`, default: `error`) — Verbosity of logging, set it to `error` in production
 
-**[channel]**
+### Channel configuration
+
+Under `[channel]`:
 
 * `inet` (type: _string_, allowed: IPv4 / IPv6 + port, default: `[::1]:1491`) — Host and TCP port Sonic Channel should listen on
 * `tcp_timeout` (type: _integer_, allowed: seconds, default: `300`) — Timeout of idle/dead client connections to Sonic Channel
 * `auth_password` (type: _string_, allowed: password values, default: none) — Authentication password required to connect to the channel (optional but recommended)
 
-**[channel.search]**
+Under `[channel.search]`:
 
 * `query_limit_default` (type: _integer_, allowed: numbers, default: `10`) — Default search results limit for a query command (if the LIMIT command modifier is not used when issuing a QUERY command)
 * `query_limit_maximum` (type: _integer_, allowed: numbers, default: `100`) — Maximum search results limit for a query command (if the LIMIT command modifier is being used when issuing a QUERY command)
@@ -24,58 +38,41 @@
 * `list_limit_default` (type: _integer_, allowed: numbers, default: `100`) — Default listed words limit for a list command (if the LIMIT command modifier is not used when issuing a LIST command)
 * `list_limit_maximum` (type: _integer_, allowed: numbers, default: `500`) — Maximum listed words limit for a list command (if the LIMIT command modifier is being used when issuing a LIST command)
 
-**[store]**
+### KV store configuration
 
-**[store.kv]**
+Under `[store.kv]`:
 
 * `path` (type: _string_, allowed: UNIX path, default: `./data/store/kv/`) — Path to the Key-Value database store
 * `retain_word_objects` (type: _integer_, allowed: numbers, default: `1000`) — Maximum number of objects a given word in the index can be linked to (older objects are cleared using a sliding window)
 
-**[store.kv.pool]**
+* `pool.inactive_after` (type: _integer_, allowed: seconds, default: `1800`) — Time after which a cached database is considered inactive and can be closed (if it is not used, ie. re-activated)
 
-* `inactive_after` (type: _integer_, allowed: seconds, default: `1800`) — Time after which a cached database is considered inactive and can be closed (if it is not used, ie. re-activated)
+* `database.flush_after` (type: _integer_, allowed: seconds, default: `900`) — Time after which pending database updates should be flushed from memory to disk (increase this delay if you encounter high-CPU usage issues when a flush task kicks-in; this value should be lower than `store.kv.pool.inactive_after`)
+* `database.compress` (type: _boolean_, allowed: `true`, `false`, default: `true`) — Whether to compress database or not (uses Zstandard)
+* `database.parallelism` (type: _integer_, allowed: numbers, default: `2`) — Limit on the number of compaction and flush threads that can run at the same time
+* `database.max_files` (type: _integer_, allowed: numbers, no default) — Maximum number of database files kept open at the same time per-database (if any; otherwise there are no limits)
+* `database.max_compactions` (type: _integer_, allowed: numbers, default: `1`) — Limit on the number of concurrent database compaction jobs
+* `database.max_flushes` (type: _integer_, allowed: numbers, default: `1`) — Limit on the number of concurrent database flush jobs
+* `database.write_buffer` (type: _integer_, allowed: numbers, default: `16384`) — Maximum size in KB of the database write buffer, after which data gets flushed to disk (ie. `16384` is `16MB`; the size should be a multiple of `1024`, eg. `128 * 1024 = 131072` for `128MB`)
+* `database.write_ahead_log` (type: _boolean_, allowed: `true`, `false`, default: `true`) — Whether to enable Write-Ahead Log or not (it avoids losing non-flushed data in case of server crash)
 
-**[store.kv.database]**
+### FST store configuration
 
-* `flush_after` (type: _integer_, allowed: seconds, default: `900`) — Time after which pending database updates should be flushed from memory to disk (increase this delay if you encounter high-CPU usage issues when a flush task kicks-in; this value should be lower than `store.kv.pool.inactive_after`)
-* `compress` (type: _boolean_, allowed: `true`, `false`, default: `true`) — Whether to compress database or not (uses Zstandard)
-* `parallelism` (type: _integer_, allowed: numbers, default: `2`) — Limit on the number of compaction and flush threads that can run at the same time
-* `max_files` (type: _integer_, allowed: numbers, no default) — Maximum number of database files kept open at the same time per-database (if any; otherwise there are no limits)
-* `max_compactions` (type: _integer_, allowed: numbers, default: `1`) — Limit on the number of concurrent database compaction jobs
-* `max_flushes` (type: _integer_, allowed: numbers, default: `1`) — Limit on the number of concurrent database flush jobs
-* `write_buffer` (type: _integer_, allowed: numbers, default: `16384`) — Maximum size in KB of the database write buffer, after which data gets flushed to disk (ie. `16384` is `16MB`; the size should be a multiple of `1024`, eg. `128 * 1024 = 131072` for `128MB`)
-* `write_ahead_log` (type: _boolean_, allowed: `true`, `false`, default: `true`) — Whether to enable Write-Ahead Log or not (it avoids losing non-flushed data in case of server crash)
-
-**[store.fst]**
+Under `[store.fst]`:
 
 * `path` (type: _string_, allowed: UNIX path, default: `./data/store/fst/`) — Path to the Finite-State Transducer database store
 
-**[store.fst.pool]**
+* `pool.inactive_after` (type: _integer_, allowed: seconds, default: `300`) — Time after which a cached graph is considered inactive and can be closed (if it is not used, ie. re-activated)
 
-* `inactive_after` (type: _integer_, allowed: seconds, default: `300`) — Time after which a cached graph is considered inactive and can be closed (if it is not used, ie. re-activated)
+* `graph.consolidate_after` (type: _integer_, allowed: seconds, default: `180`) — Time after which a graph that has pending updates should be consolidated (increase this delay if you encounter high-CPU usage issues when a consolidation task kicks-in; this value should be lower than `store.fst.pool.inactive_after`)
+* `graph.max_size` (type: _integer_, allowed: numbers, default: `2048`) — Maximum size in KB of the graph file on disk, after which further words are not inserted anymore (ie. `2048` is `2MB`; the size should be a multiple of `1024`, eg. `8 * 1024 = 8192` for `8MB`; use this limit to prevent heavy graphs to be consolidating forever; this limit is enforced in pair with `store.fst.graph.max_words`, whichever is reached first)
+* `graph.max_words` (type: _integer_, allowed: numbers, default: `250000`) — Maximum number of words that can be held at the same time in the graph, after which further words are not inserted anymore (use this limit to prevent heavy graphs to be consolidating forever; this limit is enforced in pair with `store.fst.graph.max_size`, whichever is reached first)
 
-**[store.fst.graph]**
+## Environment variables interpolation
 
-* `consolidate_after` (type: _integer_, allowed: seconds, default: `180`) — Time after which a graph that has pending updates should be consolidated (increase this delay if you encounter high-CPU usage issues when a consolidation task kicks-in; this value should be lower than `store.fst.pool.inactive_after`)
-* `max_size` (type: _integer_, allowed: numbers, default: `2048`) — Maximum size in KB of the graph file on disk, after which further words are not inserted anymore (ie. `2048` is `2MB`; the size should be a multiple of `1024`, eg. `8 * 1024 = 8192` for `8MB`; use this limit to prevent heavy graphs to be consolidating forever; this limit is enforced in pair with `store.fst.graph.max_words`, whichever is reached first)
-* `max_words` (type: _integer_, allowed: numbers, default: `250000`) — Maximum number of words that can be held at the same time in the graph, after which further words are not inserted anymore (use this limit to prevent heavy graphs to be consolidating forever; this limit is enforced in pair with `store.fst.graph.max_size`, whichever is reached first)
+Some configuration keys —namely `server.log_level`, `channel.inet`,
+`channel.auth_password`, `store.kv.path` and `store.fst.path`— support
+environment variable interpolation. If you set `"${env.SECRET}"` for one of
+those keys, the value will be expanded from the `SECRET` environment variable.
 
-## Command-Line: Environment variables
-
-You are allowed to use environment variables in the configuration file.
-
-**You can provide them as follows:**
-
-```toml
-[channel]
-
-auth_password = "${env.SECRET}"
-```
-
-**Then, you can run Sonic providing a defined environment variable:**
-
-```bash
-SECRET=secretphrase ./sonic -c /path/to/config.cfg
-```
-
-_Note that this can only be used with string-like values._
+[TOML]: https://toml.io/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "config"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "toml",
+ "winnow",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1626,7 @@ version = "1.4.9"
 dependencies = [
  "byteorder",
  "clap",
+ "config",
  "fst",
  "fst-levenshtein",
  "fst-regex",
@@ -1628,7 +1647,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "tikv-jemallocator",
- "toml",
  "twox-hash",
  "unicode-segmentation",
  "whatlang",
@@ -1764,12 +1782,10 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -1790,12 +1806,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "twox-hash"
@@ -2081,6 +2091,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ doc = false
 
 [dependencies]
 log = "0.4"
-toml = "1"
 clap = { version = "4", features = ["std", "cargo"] }
 lazy_static = "1"
 serde = "1"
@@ -42,6 +41,7 @@ jieba-rs = { version = "0.9", optional = true }
 lindera-core = { version = "0.31", optional = true }
 lindera-dictionary = { version = "0.31", features = ["unidic"], optional = true }
 lindera-tokenizer = { version = "0.31", features = ["unidic"], optional = true }
+config = { version = "0.15", default-features = false, features = ["toml"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal"] }

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -6,6 +6,10 @@ env:
   SELF: task {{ .ALIAS | default .TASK }} --
 
 tasks:
+  integration-test:
+    desc: Runs integration tests.
+    cmd: tests/integration/scripts/run.sh
+
   ci:
     desc: Runs all CI checks.
     cmds:

--- a/config.cfg
+++ b/config.cfg
@@ -3,21 +3,19 @@
 # Configuration file
 # Example: https://github.com/valeriansaliou/sonic/blob/master/config.cfg
 
-
 [server]
-
 log_level = "debug"
 
 
 [channel]
-
 inet = "[::1]:1491"
 tcp_timeout = 300
 
+# NOTE: You can pass this via `SONIC_CHANNEL__AUTH_PASSWORD`.
 auth_password = "SecretPassword"
 
-[channel.search]
 
+[channel.search]
 query_limit_default = 10
 query_limit_maximum = 100
 query_alternates_try = 4
@@ -29,41 +27,28 @@ list_limit_default = 100
 list_limit_maximum = 500
 
 
-[store]
-
 [store.kv]
-
 path = "./data/store/kv/"
 
 retain_word_objects = 1000
 
-[store.kv.pool]
+pool.inactive_after = 1800
 
-inactive_after = 1800
+database.flush_after = 900
+database.compress = true
+database.parallelism = 2
+database.max_files = 100
+database.max_compactions = 1
+database.max_flushes = 1
+database.write_buffer = 16384
+database.write_ahead_log = true
 
-[store.kv.database]
-
-flush_after = 900
-
-compress = true
-parallelism = 2
-max_files = 100
-max_compactions = 1
-max_flushes = 1
-write_buffer = 16384
-write_ahead_log = true
 
 [store.fst]
-
 path = "./data/store/fst/"
 
-[store.fst.pool]
+pool.inactive_after = 300
 
-inactive_after = 300
-
-[store.fst.graph]
-
-consolidate_after = 180
-
-max_size = 2048
-max_words = 250000
+graph.consolidate_after = 180
+graph.max_size = 2048
+graph.max_words = 250000

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -2,107 +2,42 @@
 //
 // Fast, lightweight and schema-less search backend
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
+// Copyright: 2026, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use std::net::SocketAddr;
-use std::path::PathBuf;
+pub fn defaults() -> &'static str {
+    r#"
+    [server]
+    log_level = "error"
 
-pub fn server_log_level() -> String {
-    "error".to_string()
-}
+    [channel]
+    inet = "[::1]:1491"
+    tcp_timeout = 300
+    search.query_limit_default = 10
+    search.query_limit_maximum = 100
+    search.query_alternates_try = 4
+    search.suggest_limit_default = 5
+    search.suggest_limit_maximum = 20
+    search.list_limit_default = 100
+    search.list_limit_maximum = 500
 
-pub fn channel_inet() -> SocketAddr {
-    "[::1]:1491".parse().unwrap()
-}
+    [store.kv]
+    path = "./data/store/kv/"
+    retain_word_objects = 1000
+    pool.inactive_after = 1800
+    database.flush_after = 900
+    database.compress = true
+    database.parallelism = 2
+    database.max_compactions = 1
+    database.max_flushes = 1
+    database.write_buffer = 16384
+    database.write_ahead_log = true
 
-pub fn channel_tcp_timeout() -> u64 {
-    300
-}
-
-pub fn channel_search_query_limit_default() -> u16 {
-    10
-}
-
-pub fn channel_search_query_limit_maximum() -> u16 {
-    100
-}
-
-pub fn channel_search_query_alternates_try() -> usize {
-    4
-}
-
-pub fn channel_search_suggest_limit_default() -> u16 {
-    5
-}
-
-pub fn channel_search_suggest_limit_maximum() -> u16 {
-    20
-}
-
-pub fn channel_search_list_limit_default() -> u16 {
-    100
-}
-
-pub fn channel_search_list_limit_maximum() -> u16 {
-    500
-}
-
-pub fn store_kv_path() -> PathBuf {
-    PathBuf::from("./data/store/kv/")
-}
-
-pub fn store_kv_retain_word_objects() -> usize {
-    1000
-}
-
-pub fn store_kv_pool_inactive_after() -> u64 {
-    1800
-}
-
-pub fn store_kv_database_flush_after() -> u64 {
-    900
-}
-
-pub fn store_kv_database_compress() -> bool {
-    true
-}
-
-pub fn store_kv_database_parallelism() -> u16 {
-    2
-}
-
-pub fn store_kv_database_max_compactions() -> u16 {
-    1
-}
-
-pub fn store_kv_database_max_flushes() -> u16 {
-    1
-}
-
-pub fn store_kv_database_write_buffer() -> usize {
-    16384
-}
-
-pub fn store_kv_database_write_ahead_log() -> bool {
-    true
-}
-
-pub fn store_fst_path() -> PathBuf {
-    PathBuf::from("./data/store/fst/")
-}
-
-pub fn store_fst_pool_inactive_after() -> u64 {
-    300
-}
-
-pub fn store_fst_graph_consolidate_after() -> u64 {
-    180
-}
-
-pub fn store_fst_graph_max_size() -> usize {
-    2048
-}
-
-pub fn store_fst_graph_max_words() -> usize {
-    250000
+    [store.fst]
+    path = "./data/store/fst/"
+    pool.inactive_after = 300
+    graph.consolidate_after = 180
+    graph.max_size = 2048
+    graph.max_words = 250000
+    "#
 }

--- a/src/config/env_var.rs
+++ b/src/config/env_var.rs
@@ -75,7 +75,13 @@ fn get_env_var(wrapped_key: &str) -> String {
         .drain(6..(wrapped_key.len() - 1))
         .collect();
 
-    std::env::var(key.clone()).unwrap_or_else(|_| panic!("env_var: variable '{}' is not set", key))
+    // NOTE: While we could deprecate the `${env.*}` syntax now that Sonic has
+    //   first-class support for environment variables, it would force people
+    //   to use the Sonic naming convention and potentially duplicate some
+    //   variables. For better UX, let’s keep it that way. It doesn’t require
+    //   dependencies nor bloat the code so it’s acceptable.
+
+    std::env::var(&key).unwrap_or_else(|_| panic!("env_var: variable '{key}' is not set"))
 }
 
 #[cfg(test)]

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -2,39 +2,34 @@
 //
 // Fast, lightweight and schema-less search backend
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
+// Copyright: 2026, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use super::defaults;
 use super::env_var;
 
 #[derive(Deserialize)]
 pub struct Config {
     pub server: ConfigServer,
+
     pub channel: ConfigChannel,
+
     pub store: ConfigStore,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigServer {
-    #[serde(
-        default = "defaults::server_log_level",
-        deserialize_with = "env_var::str"
-    )]
+    #[serde(deserialize_with = "env_var::str")]
     pub log_level: String,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigChannel {
-    #[serde(
-        default = "defaults::channel_inet",
-        deserialize_with = "env_var::socket_addr"
-    )]
+    #[serde(deserialize_with = "env_var::socket_addr")]
     pub inet: SocketAddr,
 
-    #[serde(default = "defaults::channel_tcp_timeout")]
     pub tcp_timeout: u64,
 
     #[serde(default, deserialize_with = "env_var::opt_str")]
@@ -45,107 +40,84 @@ pub struct ConfigChannel {
 
 #[derive(Deserialize)]
 pub struct ConfigChannelSearch {
-    #[serde(default = "defaults::channel_search_query_limit_default")]
     pub query_limit_default: u16,
 
-    #[serde(default = "defaults::channel_search_query_limit_maximum")]
     pub query_limit_maximum: u16,
 
-    #[serde(default = "defaults::channel_search_query_alternates_try")]
     pub query_alternates_try: usize,
 
-    #[serde(default = "defaults::channel_search_suggest_limit_default")]
     pub suggest_limit_default: u16,
 
-    #[serde(default = "defaults::channel_search_suggest_limit_maximum")]
     pub suggest_limit_maximum: u16,
 
-    #[serde(default = "defaults::channel_search_list_limit_default")]
     pub list_limit_default: u16,
 
-    #[serde(default = "defaults::channel_search_list_limit_maximum")]
     pub list_limit_maximum: u16,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStore {
     pub kv: ConfigStoreKV,
+
     pub fst: ConfigStoreFST,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreKV {
-    #[serde(
-        default = "defaults::store_kv_path",
-        deserialize_with = "env_var::path_buf"
-    )]
+    #[serde(deserialize_with = "env_var::path_buf")]
     pub path: PathBuf,
 
-    #[serde(default = "defaults::store_kv_retain_word_objects")]
     pub retain_word_objects: usize,
 
     pub pool: ConfigStoreKVPool,
+
     pub database: ConfigStoreKVDatabase,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreKVPool {
-    #[serde(default = "defaults::store_kv_pool_inactive_after")]
     pub inactive_after: u64,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreKVDatabase {
-    #[serde(default = "defaults::store_kv_database_flush_after")]
     pub flush_after: u64,
 
-    #[serde(default = "defaults::store_kv_database_compress")]
     pub compress: bool,
 
-    #[serde(default = "defaults::store_kv_database_parallelism")]
     pub parallelism: u16,
 
     pub max_files: Option<u32>,
 
-    #[serde(default = "defaults::store_kv_database_max_compactions")]
     pub max_compactions: u16,
 
-    #[serde(default = "defaults::store_kv_database_max_flushes")]
     pub max_flushes: u16,
 
-    #[serde(default = "defaults::store_kv_database_write_buffer")]
     pub write_buffer: usize,
 
-    #[serde(default = "defaults::store_kv_database_write_ahead_log")]
     pub write_ahead_log: bool,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreFST {
-    #[serde(
-        default = "defaults::store_fst_path",
-        deserialize_with = "env_var::path_buf"
-    )]
+    #[serde(deserialize_with = "env_var::path_buf")]
     pub path: PathBuf,
 
     pub pool: ConfigStoreFSTPool,
+
     pub graph: ConfigStoreFSTGraph,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreFSTPool {
-    #[serde(default = "defaults::store_fst_pool_inactive_after")]
     pub inactive_after: u64,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigStoreFSTGraph {
-    #[serde(default = "defaults::store_fst_graph_consolidate_after")]
     pub consolidate_after: u64,
 
-    #[serde(default = "defaults::store_fst_graph_max_size")]
     pub max_size: usize,
 
-    #[serde(default = "defaults::store_fst_graph_max_words")]
     pub max_words: usize,
 }

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -2,10 +2,8 @@
 //
 // Fast, lightweight and schema-less search backend
 // Copyright: 2019, Valerian Saliou <valerian@valeriansaliou.name>
+// Copyright: 2026, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
-
-use std::fs::File;
-use std::io::Read;
 
 use super::options::Config;
 use crate::APP_ARGS;
@@ -14,20 +12,41 @@ pub struct ConfigReader;
 
 impl ConfigReader {
     pub fn make() -> Config {
-        debug!("reading config file: {}", &APP_ARGS.config);
+        let config_path = &APP_ARGS.config;
 
-        let mut file = File::open(&APP_ARGS.config).expect("cannot find config file");
-        let mut conf = String::new();
+        // Abort if the user specified a config path that does not exist.
+        if config_path != crate::DEFAULT_CONFIG_FILE_PATH
+            && !std::path::Path::new(config_path).exists()
+        {
+            panic!("Cannot find config file at '{config_path}'");
+        }
 
-        file.read_to_string(&mut conf)
-            .expect("cannot read config file");
+        debug!("reading config file: {config_path}");
 
-        debug!("read config file: {}", &APP_ARGS.config);
+        // Read configuration.
+        let raw_config: config::Config = config::Config::builder()
+            // Start from defaults.
+            .add_source(config::File::from_str(
+                super::defaults::defaults(),
+                config::FileFormat::Toml,
+            ))
+            // Merge static configuration (from file).
+            .add_source(config::File::new(config_path, config::FileFormat::Toml).required(false))
+            // Merge environment overrides.
+            .add_source(
+                config::Environment::with_prefix("SONIC")
+                    .separator("__")
+                    .prefix_separator("_"),
+            )
+            .build()
+            .expect("error reading config");
 
-        // Parse configuration
-        let config = toml::from_str(&conf).expect("syntax error in config file");
+        // Parse configuration.
+        let config = raw_config
+            .try_deserialize::<Config>()
+            .expect("syntax error in config");
 
-        // Validate configuration
+        // Validate configuration.
         Self::validate(&config);
 
         config

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,8 @@ gen_spawn_managed!(
 );
 gen_spawn_managed!("tasker", spawn_tasker, THREAD_NAME_TASKER, TaskerBuilder);
 
+const DEFAULT_CONFIG_FILE_PATH: &str = "./config.cfg";
+
 fn make_app_args() -> AppArgs {
     let matches = Command::new(clap::crate_name!())
         .version(clap::crate_version!())
@@ -117,7 +119,7 @@ fn make_app_args() -> AppArgs {
                 .short('c')
                 .long("config")
                 .help("Path to configuration file")
-                .default_value("./config.cfg"),
+                .default_value(DEFAULT_CONFIG_FILE_PATH),
         )
         .get_matches();
 

--- a/tests/integration/instance/config.cfg
+++ b/tests/integration/instance/config.cfg
@@ -2,22 +2,8 @@
 # Configuration file (integration tests)
 
 [server]
-
 log_level = "warn"
 
 [channel]
-
 inet = "127.0.0.1:1491"
 auth_password = "password:test"
-
-[channel.search]
-
-[store]
-
-[store.kv]
-[store.kv.pool]
-[store.kv.database]
-
-[store.fst]
-[store.fst.pool]
-[store.fst.graph]


### PR DESCRIPTION
Variables named `SONIC_FOO__BAR__BAZ` are now interpreted as `foo.bar.baz`, removing the need for a configuration file.

Thanks to parsing improvements, it is not necessary to define all keys (even empty) anymore.

It unlocks new possibilities and simplifies future test tooling, in addition to having been requested in
<https://github.com/valeriansaliou/sonic/issues/326#issuecomment-4453757465>.

Note that while updating `CONFIGURATION.md` I removed the `SECRET=secretphrase ./sonic -c /path/to/config.cfg` code block as it’s not a good practice to provide secrets this way (commands can be logged). If users use environment variables, they likely know how to make them visible to Sonic.