### PR TITLE
fix(core): Perform implicit `AND` when `QUERY`ing an ID

### DIFF
--- a/core/src/executor/search.rs
+++ b/core/src/executor/search.rs
@@ -111,6 +111,14 @@ impl super::Executor {
                 );
 
                 'terms: for (idx, (term, _, original_len)) in terms.iter().enumerate() {
+                    // Skip term if it’s an ID (we want exact matches only).
+                    if term.chars().any(is_considered_id_char) {
+                        tracing::debug!(
+                            "skipping prefix search for {term:?}: term is considered an ID"
+                        );
+                        continue 'terms;
+                    };
+
                     let Some(suggestions) = fst_action.lookup_begins(term, *original_len) else {
                         tracing::trace!("did not get any completed word for term {term:?}");
                         continue 'terms;
@@ -140,6 +148,14 @@ impl super::Executor {
                 );
 
                 'terms: for (idx, (term, _, original_word_len)) in terms.iter().enumerate() {
+                    // Skip term if it’s an ID (we want exact matches only).
+                    if term.chars().any(is_considered_id_char) {
+                        tracing::debug!(
+                            "skipping fuzzy matching for {term:?}: term is considered an ID"
+                        );
+                        continue 'terms;
+                    };
+
                     let max_typo_factor = typo_factor(*original_word_len);
                     let mut typo_factor = 1u32;
 
@@ -170,6 +186,27 @@ impl super::Executor {
 
             #[cfg(debug_assertions)]
             tracing::debug!(?scoring_matrix);
+
+            // Switch to implicit `AND` if query contains an ID.
+            // NOTE: When a user queries for an ID (e.g. UUID), they expect only
+            //   exact matches to be returned. If one term is considered an ID,
+            //   we drop all results missing at least one term. It’s not the
+            //   most efficient (compared to not storing the result in the first
+            //   place) but it’s an edge case and the cost is negligible.
+            let one_term_is_an_id = terms.iter().any(|(term, _, _)| is_considered_id(term));
+            if one_term_is_an_id {
+                let mut to_remove = Vec::<StoreObjectIID>::new();
+
+                for (&iid, scores) in scoring_matrix.iter() {
+                    if scores.contains(&MISSING_MATCH_SCORE) {
+                        to_remove.push(iid);
+                    }
+                }
+
+                for iid in to_remove {
+                    scoring_matrix.swap_remove(&iid);
+                }
+            }
 
             // Flatten scores, taking into account missing matches (thanks to
             // `MISSING_MATCH_SCORE`).
@@ -206,6 +243,14 @@ impl super::Executor {
 
         Err(())
     }
+}
+
+fn is_considered_id(s: &str) -> bool {
+    s.chars().any(is_considered_id_char)
+}
+
+fn is_considered_id_char(c: char) -> bool {
+    c.is_ascii_digit()
 }
 
 #[allow(clippy::too_many_arguments)] // We’ll refactor this someday, and it’ not public anyway.

--- a/core/tests/loose_matching.rs
+++ b/core/tests/loose_matching.rs
@@ -15,7 +15,6 @@ use crate::common::*;
 fn test_search_is_case_insensitive_simple() {
     init_logging();
 
-    #[rustfmt::skip]
     let examples = [
         ("HeLLo", "hello"),
         ("ΚΌΣΜΟΣ", "κόσμος"),
@@ -43,7 +42,6 @@ fn test_search_is_case_insensitive_simple() {
 fn test_search_is_case_insensitive_proper() {
     init_logging();
 
-    #[rustfmt::skip]
     let examples = [
         ("ΚΌΣΜΟΣ", "κόσμοσ"),
         ("ΚΌΣΜΟΣ", "κόσμος"),
@@ -70,7 +68,6 @@ fn test_search_is_case_insensitive_proper() {
 fn test_search_is_unicode_normalized() {
     init_logging();
 
-    #[rustfmt::skip]
     let examples = [
         // Ligatures
         ("ﬃ", "ffi"),
@@ -100,7 +97,6 @@ fn test_search_is_unicode_normalized() {
 ///   v1.6.0 Sonic was storing non-normalized words in the FST.
 #[test]
 fn test_search_is_diacritics_insensitive() {
-    #[rustfmt::skip]
     test_ingest_then_query!(
         normalization_config: { diacritic_folding_enabled: true },
         search_config: { fuzzy_matching_enabled: false, prefix_matching_enabled: false },
@@ -111,7 +107,6 @@ fn test_search_is_diacritics_insensitive() {
     );
 
     // Example from <https://github.com/valeriansaliou/sonic/issues/245>.
-    #[rustfmt::skip]
     test_ingest_then_query!(
         normalization_config: { diacritic_folding_enabled: true },
         search_config: { fuzzy_matching_enabled: false, prefix_matching_enabled: true },
@@ -121,4 +116,47 @@ fn test_search_is_diacritics_insensitive() {
             ("Veronika S", true),
         ],
     );
+}
+
+#[test]
+fn test_no_fuzzy_matching_for_ids() {
+    init_logging();
+
+    let examples = [
+        // UUID.
+        (
+            vec![
+                "My user ID is \"6db14cb4-b82e-4e49-8016-ef76c4290a2f\"",
+                "My user ID is `6db14cb4-b82e-4e49-8016-ef76c4290a2e`",
+            ],
+            "6db14cb4-b82e-4e49-8016-ef76c4290a2f",
+        ),
+        // One term in the query (`abcd`) has only letters.
+        (
+            vec![
+                "My user ID is 6db14cb4-abcd-4e49-8016-ef76c4290a2e",
+                "My user ID is 6db14cb4-cdef-4e49-8016-ef76c4290a2e",
+            ],
+            "6db14cb4-abcd-4e49-8016-ef76c4290a2e",
+        ),
+        // Phone number like.
+        (
+            vec!["Here it is: 1234-567890-12", "Here it is: 1234-567890-13"],
+            "1234-567890-12",
+        ),
+    ];
+
+    for (example_idx, (messages, query)) in examples.into_iter().enumerate() {
+        let executor = make_test_executor_with_id(example_idx);
+
+        for (message_idx, &message) in messages.iter().enumerate() {
+            let id = &format!("chat:{message_idx}");
+            exec!(executor -> PUSH "messages" "user:1" id message);
+        }
+        exec!(executor -> TRIGGER consolidate);
+
+        let response = exec!(executor -> QUERY "messages" "user:1" query);
+
+        assert_eq!(response, ["chat:0"], "({messages:?}, {query:?})");
+    }
 }


### PR DESCRIPTION
Users complained that searching for IDs now returned non-exact matches. I added an opinionated override that discard all non-exact matches if a search term contains an ASCII digit. 