### PR TITLE
feat(core): Consider more strings to be IDs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,8 +134,8 @@ jobs:
           rustup --version 2>/dev/null
           cargo --version
 
-      - name: Build code
-        run: cargo build --locked
+      - name: Build Sonic server
+        run: cargo build --locked --bin sonic --no-default-features -F stemming
 
-      - name: Test code
-        run: cargo test --locked
+      - name: Test all
+        run: cargo test --locked --no-default-features -F stemming

--- a/core/src/executor/search.rs
+++ b/core/src/executor/search.rs
@@ -112,6 +112,8 @@ impl super::Executor {
 
                 'terms: for (idx, (term, _, original_len)) in terms.iter().enumerate() {
                     // Skip term if it’s an ID (we want exact matches only).
+                    // FIXME: We’d like to enable prefix matching for IDs, but
+                    //   the way the tokenizer works causes false positives.
                     if is_considered_id(&term) {
                         tracing::debug!(
                             "skipping prefix search for {term:?}: term is considered an ID"

--- a/core/src/executor/search.rs
+++ b/core/src/executor/search.rs
@@ -112,7 +112,7 @@ impl super::Executor {
 
                 'terms: for (idx, (term, _, original_len)) in terms.iter().enumerate() {
                     // Skip term if it’s an ID (we want exact matches only).
-                    if term.chars().any(is_considered_id_char) {
+                    if is_considered_id(&term) {
                         tracing::debug!(
                             "skipping prefix search for {term:?}: term is considered an ID"
                         );
@@ -149,7 +149,7 @@ impl super::Executor {
 
                 'terms: for (idx, (term, _, original_word_len)) in terms.iter().enumerate() {
                     // Skip term if it’s an ID (we want exact matches only).
-                    if term.chars().any(is_considered_id_char) {
+                    if is_considered_id(&term) {
                         tracing::debug!(
                             "skipping fuzzy matching for {term:?}: term is considered an ID"
                         );
@@ -246,11 +246,62 @@ impl super::Executor {
 }
 
 fn is_considered_id(s: &str) -> bool {
-    s.chars().any(is_considered_id_char)
+    s.chars().any(|c| c.is_ascii_digit() || c == '@')
+        || s.chars()
+            // Skip first char.
+            .skip(1)
+            // Skip last char.
+            .take(s.len().saturating_sub(2))
+            .any(is_non_prose_char)
 }
 
-fn is_considered_id_char(c: char) -> bool {
-    c.is_ascii_digit()
+fn is_non_prose_char(c: char) -> bool {
+    c == '.' || c == '_' || c == ':' || c == '\\' || c == '+' || c == '=' || c == '&'
+}
+
+/// Note that the tokenizer might split the tested strings in ways that make
+/// Sonic as a whole behave differently! This is just a simple unit test.
+#[cfg(test)]
+#[test]
+fn test_is_considered_id() {
+    // Sanity check.
+    assert!(!is_considered_id("Hello"));
+
+    // Phone number like.
+    assert!(is_considered_id("1234-567890-12"));
+    assert!(is_considered_id("0123456789"));
+
+    // UUID like.
+    assert!(is_considered_id("6db14cb4-b82e-4e49-8016-ef76c4290a2f"));
+
+    // Hash like.
+    assert!(is_considered_id("b244423d417369795292e9f4530d0c0e6fa07625"));
+    assert!(is_considered_id("b244423"));
+
+    // Code like.
+    assert!(is_considered_id("is_considered_id"));
+
+    // Domain name.
+    assert!(is_considered_id("example.org"));
+    assert!(!is_considered_id("endofsentence."));
+    assert!(!is_considered_id(".startofsentence"));
+
+    // URL.
+    assert!(is_considered_id("https://example.org/foo?id=123"));
+
+    // Email address.
+    assert!(is_considered_id("alice@example.org"));
+    assert!(is_considered_id("alice+foo@example.org"));
+
+    // IP addresses.
+    assert!(is_considered_id("192.168.1.0"));
+    assert!(is_considered_id("0.0.0.0"));
+    assert!(is_considered_id("2606:4700::6812:1c68"));
+    assert!(is_considered_id("::1"));
+    assert!(!is_considered_id("example:"));
+
+    // Username.
+    assert!(is_considered_id("@example"));
 }
 
 #[allow(clippy::too_many_arguments)] // We’ll refactor this someday, and it’ not public anyway.

--- a/core/tests/loose_matching.rs
+++ b/core/tests/loose_matching.rs
@@ -122,40 +122,118 @@ fn test_search_is_diacritics_insensitive() {
 fn test_no_fuzzy_matching_for_ids() {
     init_logging();
 
+    struct TestMatches1st<'a> {
+        messages: Vec<&'a str>,
+        query: &'a str,
+    }
+
+    // In those examples, multiple messages are pushed into the index,
+    // and only the first is supposed to match the given query.
     let examples = [
-        // UUID.
-        (
-            vec![
+        // UUID like.
+        TestMatches1st {
+            messages: vec![
                 "My user ID is \"6db14cb4-b82e-4e49-8016-ef76c4290a2f\"",
                 "My user ID is `6db14cb4-b82e-4e49-8016-ef76c4290a2e`",
             ],
-            "6db14cb4-b82e-4e49-8016-ef76c4290a2f",
-        ),
-        // One term in the query (`abcd`) has only letters.
-        (
-            vec![
+            query: "6db14cb4-b82e-4e49-8016-ef76c4290a2f",
+        },
+        TestMatches1st {
+            // Note that one term in the query (`abcd`) has only letters.
+            messages: vec![
                 "My user ID is 6db14cb4-abcd-4e49-8016-ef76c4290a2e",
                 "My user ID is 6db14cb4-cdef-4e49-8016-ef76c4290a2e",
             ],
-            "6db14cb4-abcd-4e49-8016-ef76c4290a2e",
-        ),
+            query: "6db14cb4-abcd-4e49-8016-ef76c4290a2e",
+        },
         // Phone number like.
-        (
-            vec!["Here it is: 1234-567890-12", "Here it is: 1234-567890-13"],
-            "1234-567890-12",
-        ),
+        TestMatches1st {
+            messages: vec!["Here it is: 1234-567890-12", "Here it is: 1234-567890-13"],
+            query: "1234-567890-12",
+        },
+        TestMatches1st {
+            messages: vec!["Here it is: 0123456789", "Here it is: 0123456780"],
+            query: "0123456789",
+        },
+        // Email address.
+        TestMatches1st {
+            messages: vec![
+                "Contact me at alice@example.org",
+                "Son e-mail: alice@exemple.org",
+            ],
+            query: "alice@example.org",
+        },
+        TestMatches1st {
+            messages: vec![
+                "Contact me at alice+foo@example.org",
+                "Son e-mail: alice+foo@exemple.org",
+            ],
+            query: "alice+foo@example.org",
+        },
+        // Hash like.
+        TestMatches1st {
+            messages: vec![
+                "It’s in b244423d417369795292e9f4530d0c0e6fa07625",
+                "It’s in b244423d41736979529209f4530d0c0e6fa07625",
+            ],
+            query: "b244423d417369795292e9f4530d0c0e6fa07625",
+        },
+        TestMatches1st {
+            messages: vec!["It’s in b244423", "It’s in b242423"],
+            query: "b244423",
+        },
+        // Code like.
+        TestMatches1st {
+            messages: vec!["Check out ingest_flushc", "Look at ingest_flushb"],
+            query: "ingest_flushc",
+        },
+        // Domain name.
+        TestMatches1st {
+            messages: vec!["The client is example.org.", "Their homepage: exemple.org."],
+            query: "example.org",
+        },
+        // URL.
+        TestMatches1st {
+            messages: vec![
+                "All data is in https://example.org/foo?id=123",
+                "See https://example.org/foo?id=124",
+            ],
+            query: "https://example.org/foo?id=123",
+        },
+        // IP addresses.
+        TestMatches1st {
+            messages: vec!["192.168.1.0", "192.168.1.1"],
+            query: "192.168.1.0",
+        },
+        TestMatches1st {
+            messages: vec!["0.0.0.0", "0.0.0.1"],
+            query: "0.0.0.0",
+        },
+        TestMatches1st {
+            messages: vec!["2606:4700::6812:1c68", "2606:4700::6812:1c60"],
+            query: "2606:4700::6812:1c68",
+        },
+        TestMatches1st {
+            messages: vec!["::1", "::2"],
+            query: "::1",
+        },
+        // Username.
+        TestMatches1st {
+            messages: vec!["@example1", "@example2"],
+            query: "@example1",
+        },
     ];
 
-    for (example_idx, (messages, query)) in examples.into_iter().enumerate() {
+    for (example_idx, TestMatches1st { messages, query }) in examples.into_iter().enumerate() {
         let executor = make_test_executor_with_id(example_idx);
 
         for (message_idx, &message) in messages.iter().enumerate() {
             let id = &format!("chat:{message_idx}");
-            exec!(executor -> PUSH "messages" "user:1" id message);
+            exec!(executor -> PUSH "messages" "user:1" id message LANG("eng"));
         }
         exec!(executor -> TRIGGER consolidate);
 
-        let response = exec!(executor -> QUERY "messages" "user:1" query);
+        let response = exec!(executor -> QUERY "messages" "user:1" query LANG("eng"));
 
         assert_eq!(response, ["chat:0"], "({messages:?}, {query:?})");
     }


### PR DESCRIPTION
A lot of people complained about “regressions” when they query emails. They expect exact matches, which makes sense, but because we fixed fuzzy matching, we now return results that are too far from what users expect.

Note that email address used to be fuzzy matched before, but for statistical reasons people didn’t notice. Usernames were allowed 1 wrong character and domain names too, resulting in a match potentially wrong by two characters. But because this is very unlikely, no one noticed.

I added more cases like domain names, URLs, IP addresses, usernames, etc. so we cover as much of what people expect as possible. Because of how the tokenizer works, we can’t be as precise as I’d like to, but changing the tokenizer would force people to rebuild their Sonic index which we don’t want until a major version change. It’s still planned though, and I’ll hide it behind an opt-in configuration key.