### PR TITLE
Make tokenizer pattern matching non-breaking

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -40,7 +40,9 @@ stemming_enabled = false
 # etc. and ensures they are both not split by the tokenizer and matched exactly
 # in queries.
 # TODO(major): Remove explicit override.
-detect_special_patterns = false
+detect_special_patterns = true
+# TODO(major): Remove explicit override.
+compat_split_special_patterns = true
 
 
 [search]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -61,6 +61,9 @@ pub struct ConfigNormalization {
 #[derive(Deserialize, Clone, Copy)]
 pub struct ConfigTokenization {
     pub detect_special_patterns: bool,
+
+    #[serde(alias = "split_special_patterns")]
+    pub compat_split_special_patterns: bool,
 }
 
 #[derive(Deserialize)]
@@ -161,6 +164,7 @@ pub(crate) mod tests {
 
         [tokenization]
         detect_special_patterns = true
+        compat_split_special_patterns = false
 
         [search]
         query_limit_default = 10

--- a/core/src/lexer/token.rs
+++ b/core/src/lexer/token.rs
@@ -23,7 +23,7 @@ use super::stopwords::LexerStopWord;
 
 pub struct TokenLexerBuilder;
 
-type WordsIter<'s> = Box<dyn Iterator<Item = &'s str> + 's>;
+type TokensIter<'s> = Box<dyn Iterator<Item = Token<'s>> + 's>;
 
 static SPECIAL_PATTERNS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(concat!(
@@ -39,11 +39,12 @@ static SPECIAL_PATTERNS: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 pub struct Tokenizer<'s> {
+    config: ConfigTokenization,
     text: &'s str,
     lang: Option<Lang>,
     regex_matches: Peekable<regex::CaptureMatches<'static, 's>>,
     regex_cursor: usize,
-    words: Option<(WordsIter<'s>, usize)>,
+    tokens: Option<(TokensIter<'s>, usize)>,
 }
 
 impl<'s> Tokenizer<'s> {
@@ -57,11 +58,12 @@ impl<'s> Tokenizer<'s> {
         };
 
         Self {
+            config: *config,
             lang,
             regex_matches,
             text,
             regex_cursor: 0,
-            words: None,
+            tokens: None,
         }
     }
 }
@@ -93,12 +95,12 @@ impl<'s> Iterator for Tokenizer<'s> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // If we were walking words, continue.
-        if let Some((words, end)) = self.words.as_mut() {
+        if let Some((words, end)) = self.tokens.as_mut() {
             match words.next() {
-                Some(w) => return Some(Token::Word(w)),
+                Some(word) => return Some(word),
                 None => {
                     self.regex_cursor = *end;
-                    self.words = None;
+                    self.tokens = None;
                 }
             }
         }
@@ -106,29 +108,48 @@ impl<'s> Iterator for Tokenizer<'s> {
         // Check where the next special chunk is located.
         match self.regex_matches.peek() {
             Some(captures) => {
-                let m = captures.get_match();
-                let start = m.start();
-                let end = m.end();
+                let regex_match = captures.get_match();
+                let start = regex_match.start();
+                let end = regex_match.end();
 
                 // Up until that special chunk, tokenize normally.
                 if start > self.regex_cursor {
                     let gap = &self.text[self.regex_cursor..start];
-                    let mut words = tokenize(gap, self.lang);
+                    let mut tokens = Box::new(tokenize(gap, self.lang).map(Token::Word));
 
-                    if let Some(w) = words.next() {
-                        self.words = Some((words, end));
-                        return Some(Token::Word(w));
+                    if let Some(token) = tokens.next() {
+                        self.tokens = Some((tokens, end));
+                        return Some(token);
                     }
                 }
 
                 // Once all normal words have been visited, yield the special
                 // chunk.
-                self.regex_cursor = end;
-                let next = Some(Token::special(captures));
+                let next = if self.config.compat_split_special_patterns {
+                    let regex_match = captures.get_match().as_str();
+                    let words = tokenize(regex_match, self.lang);
+
+                    let mut words = Box::new(words.map(|raw| Token::Special {
+                        raw,
+                        normalized: Cow::Borrowed(raw),
+                    }));
+
+                    let next = words.next().unwrap_or(Token::Special {
+                        raw: regex_match,
+                        normalized: Cow::Borrowed(regex_match),
+                    });
+
+                    self.tokens = Some((words, end));
+
+                    Some(next)
+                } else {
+                    Some(Token::special(captures))
+                };
 
                 // Advance the iterator now that we’ve visited all previous
                 // tokens.
                 self.regex_matches.next();
+                self.regex_cursor = end;
 
                 next
             }
@@ -136,11 +157,11 @@ impl<'s> Iterator for Tokenizer<'s> {
                 // When there are no more special chunks, finish by tokenizing
                 // normally.
                 let gap = &self.text[self.regex_cursor..];
-                let mut words = tokenize(gap, self.lang);
+                let mut tokens = Box::from(tokenize(gap, self.lang).map(Token::Word));
 
-                if let Some(w) = words.next() {
-                    self.words = Some((words, self.text.len()));
-                    return Some(Token::Word(w));
+                if let Some(token) = tokens.next() {
+                    self.tokens = Some((tokens, self.text.len()));
+                    return Some(token);
                 }
 
                 None
@@ -659,6 +680,7 @@ mod tests {
     };
     const TOKENIZATION_CONFIG: ConfigTokenization = ConfigTokenization {
         detect_special_patterns: true,
+        compat_split_special_patterns: false,
     };
 
     #[test]

--- a/core/src/query/builder.rs
+++ b/core/src/query/builder.rs
@@ -176,6 +176,7 @@ mod tests {
     };
     const TOKENIZATION_CONFIG: ConfigTokenization = ConfigTokenization {
         detect_special_patterns: true,
+        compat_split_special_patterns: false,
     };
 
     #[test]

--- a/core/tests/common/config.rs
+++ b/core/tests/common/config.rs
@@ -42,6 +42,7 @@ pub fn defaults_toml() -> String {
 
         [tokenization]
         detect_special_patterns = true
+        compat_split_special_patterns = false
 
         [search]
         query_limit_default = 10

--- a/docs/tokenizer-pattern-matching.md
+++ b/docs/tokenizer-pattern-matching.md
@@ -1,0 +1,215 @@
+---
+author: Rémi Bardon <remi@remibardon.name>
+created: 2026-07-09
+---
+
+# Sonic tokenizer’s pattern matching
+
+## Context
+
+Since its very beginning, Sonic has always supported prefix and fuzzy matching.
+However, at some point a bug creeped in and caused fuzzy matching to correct at
+most 1 typo. This bug went unnoticed for years and users became used to it.
+
+Let’s take a simplified example (pseudo-code):
+
+```txt
+Ingest (Sonic <= v1.7.3):
+  PUSH doc:1 "olivia@example.org"
+              └────┘ └─────────┘
+  PUSH doc:2 "olivio@example.org" # Lev(doc:1, doc:2) = 1
+              └────┘ └─────────┘
+  PUSH doc:3 "alicia@example.org" # Lev(doc:1, doc:3) = 2
+              └────┘ └─────────┘
+  PUSH doc:4 "olivia@example.com" # Lev(doc:1, doc:4) = 3
+              └────┘ └─────────┘
+  PUSH doc:5 "olivia and olivio"
+              └────┘ └─┘ └────┘
+
+In the index: {
+  "olivia", "example.org", "olivio", "alicia", "example.com", "and"
+}
+```
+
+Before `v1.7.0`, because typo correction was always limited to 1 character,
+searching for `olivia@example.org` would yield the following results:
+
+```txt
+Search (v1.6.0):
+  QUERY "olivia@example.org"
+         └─┬──┘ └────┬────┘
+         1 typo    1 typo
+       ┌───┴───┐     └───┐
+     olivia  olivio  example.org
+       └─ OR ──┘         │
+          └───── AND ────┘
+  RESULT doc:2 doc:1 # Too many results (expected: doc:1)
+```
+
+However, because 1 character differences in both the username or domain part of
+an email address are very unlikely, no one ever noticed (and complained).
+
+## The v1.7.0 problem
+
+In v1.7.0 we fixed Sonic’s typo correction, which now allows more typos as the
+word gets longer (which was supposed to happen since the beginning).
+Unfortunately, this fix didn’t go unnoticed, as it only took a few hours after
+deployment for [Crisp] users to start complaining about unexpected results when
+querying phone numbers or email addresses.
+
+[Crisp]: https://crisp.chat "Crisp homepage"
+
+In `v1.7.0`, searching for `olivia@example.org` would now yield far too many
+results:
+
+```txt
+Note: In `v1.7.0`, 6-letters words are allowed 1 typo. For example’s sake,
+we’ll pretend `olivia` is 7-letters long so it matches up to 2 typos. Off the
+top of my head I couldn’t find better examples.
+
+Search (v1.7.0):
+  QUERY "olivia@example.org"
+         └─┬──┘ └────┬────┘
+        2 typos      └── 3 typos ───┐
+      ┌────┴──┬───────┐         ┌───┴────────┐
+    olivia  olivio  alicia  example.org  example.com
+      └───────┴─ OR ──┘         └──── OR ────┘
+                  └─────── OR ────────┘
+  RESULT doc:1 doc:2 doc:3 doc:4 doc:5 # Too many results (expected: doc:1)
+```
+
+Although results were ordered perfectly, users were expecting not to see fuzzy
+matches at all. We didn’t want to revert the typo correction fix, as it made
+sense for a ton of use cases, and had to come up with a non-breaking workaround.
+
+## Workaround: Forcing some terms to be matched exactly, and at least once
+
+In [Pull Request #365] and [Pull Request #367] we made changes to the `QUERY`
+executor so it would consider any term containing non-prose characters (e.g.
+digits, `.`, `_`, etc.) to be an identifier. Identifiers would then not be
+subject to prefix nor fuzzy matching, and they would be required to be present
+in all results (implicit `AND`). This was a huge win, but it still had flaws:
+
+[Pull Request #365]: https://github.com/valeriansaliou/sonic/pull/365
+[Pull Request #367]: https://github.com/valeriansaliou/sonic/pull/367
+
+```txt
+Search (v1.7.3):
+  QUERY "olivia@example.org"
+         └─┬──┘ └────┬────┘
+        2 typos      └─ Exact ──┐
+      ┌────┴──┬───────┐         │
+    olivia  olivio  alicia  example.org
+      └───────┴─ OR ──┘         │
+                  └──── AND ────┘
+  RESULT doc:1 doc:2 doc:3 # Better than v1.7.0, but still too many results
+                           # and arguably worse than v1.6.0 (expected: doc:1)
+```
+
+Because the tokenizer would split on `@`, `olivia` couldn’t be detected as an
+identifier, and would still be fuzzy matched too broadly. Without making
+changes to the tokenizer, working around this issue would have been very hacky,
+so we went on and changed it.
+
+## Solution: Making it so the tokenizer doesn’t split specific patterns
+
+In [Pull Request #368], we made changes to the tokenizer so it could detect
+some patterns (e.g. emails, phone numbers, UUIDs…). For those portions of the
+query, because users expect exact matches, we’d disable fuzzy matching and
+force the term to be present in results.
+
+[Pull Request #368]: https://github.com/valeriansaliou/sonic/pull/368
+
+Unfortunately, without rebuilding Sonic’s index, the `QUERY` executor would
+look for terms that are not in the index, making this a breaking change:
+
+```txt
+Index (<= v1.7.3): {
+  "olivia", "example.org", "olivio", "alicia", "example.com", "and"
+}
+
+Search (f290006):
+  QUERY "olivia@example.org"
+         └──────┬─────────┘
+              Exact
+                │
+                ø
+  RESULT # Regression: no more result
+```
+
+To avoid having to make a major release for Sonic, we hid this new feature
+behind an opt-in configuration flag: `tokenization.detect_special_patterns`.
+At least indexes wouldn’t become useless on update, but we were back to square
+one (or `v1.7.3` to be more precise):
+
+```txt
+Search (ddd6848 with `tokenization.detect_special_patterns = false`):
+  Same as in v1.7.3 (not great)
+```
+
+## Improvement: Making the solution non-breaking
+
+At [Crisp] we can’t just rebuild the index because we’re bumping Sonic, because
+—even though Sonic is fast— ingesting billions of messages still takes _hours_,
+so it was time to look for a smarter idea.
+
+If we want to get the results users expect (i.e. just `doc:1` in our example),
+the tokenizer _has to_ be aware of patterns. But we also can’t force a rebuild
+of the index in a non-breaking release, so we have to act in-between.
+
+The solution we came up with is to enable `tokenization.detect_special_patterns`
+by default but add `tokenization.split_special_patterns` to control whether or
+not they should be further split. When `true`, terms are split just like in
+`v1.6.0`, but they are now marked special and we can force exact matching. Here
+is an example:
+
+```txt
+Index (<= v1.7.3): {
+  "olivia", "example.org", "olivio", "alicia", "example.com", "and"
+}
+
+Search (v1.7.4 with `tokenization.split_special_patterns = true`):
+  QUERY "olivia@example.org"
+         └── Special ─────┘
+         └─┬──┘ └────┬────┘
+         Exact     Exact
+           │         │
+         olivia  example.org
+           └── AND ──┘
+  RESULT doc:1 # Expected result
+```
+
+In this example, the result is exactly what we want, but there is still one
+edge case where a document contains both `olivia` and `example.org` (but not
+`olivia@example.org`). Unfortunately it’s not possible for Sonic to work around
+this case without its index being rebuilt with
+`tokenization.split_special_patterns = false` (which will be the default in
+Sonic `v2.0.0`). Here is why it would be perfect:
+
+```txt
+Ingest (v1.7.4 with `tokenization.split_special_patterns = false`):
+  PUSH doc:1 "olivia@example.org"
+              └────────────────┘
+  PUSH doc:2 "olivio@example.org"
+              └────────────────┘
+  PUSH doc:3 "alicia@example.org"
+              └────────────────┘
+  PUSH doc:4 "olivia@example.com"
+              └────────────────┘
+  PUSH doc:5 "olivia and olivio"
+              └────┘ └─┘ └────┘
+
+In the index: {
+  "olivia@example.org", "olivio@example.org", "alicia@example.org",
+  "olivia@example.com", "olivia", "and", "olivio"
+}
+
+Search (v1.7.4 with `tokenization.split_special_patterns = false`):
+  QUERY "olivia@example.org"
+         └── Special ─────┘
+                │
+              Exact
+                │
+         olivia@example.org
+  RESULT doc:1 # Perfect!
+```

--- a/docs/tokenizer-pattern-matching.md
+++ b/docs/tokenizer-pattern-matching.md
@@ -15,15 +15,15 @@ Let’s take a simplified example (pseudo-code):
 
 ```txt
 Ingest (Sonic <= v1.7.3):
-  PUSH doc:1 "olivia@example.org"
+  PUSH msg:1 "olivia@example.org"
               └────┘ └─────────┘
-  PUSH doc:2 "olivio@example.org" # Lev(doc:1, doc:2) = 1
+  PUSH msg:2 "olivio@example.org" # Lev(msg:1, msg:2) = 1
               └────┘ └─────────┘
-  PUSH doc:3 "alicia@example.org" # Lev(doc:1, doc:3) = 2
+  PUSH msg:3 "alicia@example.org" # Lev(msg:1, msg:3) = 2
               └────┘ └─────────┘
-  PUSH doc:4 "olivia@example.com" # Lev(doc:1, doc:4) = 3
+  PUSH msg:4 "olivia@example.com" # Lev(msg:1, msg:4) = 3
               └────┘ └─────────┘
-  PUSH doc:5 "olivia and olivio"
+  PUSH msg:5 "olivia and olivio"
               └────┘ └─┘ └────┘
 
 In the index: {
@@ -43,7 +43,7 @@ Search (v1.6.0):
      olivia  olivio  example.org
        └─ OR ──┘         │
           └───── AND ────┘
-  RESULT doc:2 doc:1 # Too many results (expected: doc:1)
+  RESULT msg:2 msg:1 # Too many results (expected: msg:1)
 ```
 
 However, because 1 character differences in both the username or domain part of
@@ -75,7 +75,7 @@ Search (v1.7.0):
     olivia  olivio  alicia  example.org  example.com
       └───────┴─ OR ──┘         └──── OR ────┘
                   └─────── OR ────────┘
-  RESULT doc:1 doc:2 doc:3 doc:4 doc:5 # Too many results (expected: doc:1)
+  RESULT msg:1 msg:2 msg:3 msg:4 msg:5 # Too many results (expected: msg:1)
 ```
 
 Although results were ordered perfectly, users were expecting not to see fuzzy
@@ -102,8 +102,8 @@ Search (v1.7.3):
     olivia  olivio  alicia  example.org
       └───────┴─ OR ──┘         │
                   └──── AND ────┘
-  RESULT doc:1 doc:2 doc:3 # Better than v1.7.0, but still too many results
-                           # and arguably worse than v1.6.0 (expected: doc:1)
+  RESULT msg:1 msg:2 msg:3 # Better than v1.7.0, but still too many results
+  # and arguably worse than v1.6.0 (expected: msg:1)
 ```
 
 Because the tokenizer would split on `@`, `olivia` couldn’t be detected as an
@@ -153,22 +153,22 @@ At [Crisp] we can’t just rebuild the index because we’re bumping Sonic, beca
 —even though Sonic is fast— ingesting billions of messages still takes _hours_,
 so it was time to look for a smarter idea.
 
-If we want to get the results users expect (i.e. just `doc:1` in our example),
+If we want to get the results users expect (i.e. just `msg:1` in our example),
 the tokenizer _has to_ be aware of patterns. But we also can’t force a rebuild
 of the index in a non-breaking release, so we have to act in-between.
 
 The solution we came up with is to enable `tokenization.detect_special_patterns`
-by default but add `tokenization.split_special_patterns` to control whether or
-not they should be further split. When `true`, terms are split just like in
-`v1.6.0`, but they are now marked special and we can force exact matching. Here
-is an example:
+by default but add `tokenization.compat_split_special_patterns` to control
+whether or not they should be further split. When `true`, terms are split just
+like in `v1.6.0`, but they are now marked special and we can force exact
+matching. Here is an example:
 
 ```txt
 Index (<= v1.7.3): {
   "olivia", "example.org", "olivio", "alicia", "example.com", "and"
 }
 
-Search (v1.7.4 with `tokenization.split_special_patterns = true`):
+Search (v1.7.4 with `tokenization.compat_split_special_patterns = true`):
   QUERY "olivia@example.org"
          └── Special ─────┘
          └─┬──┘ └────┬────┘
@@ -176,27 +176,27 @@ Search (v1.7.4 with `tokenization.split_special_patterns = true`):
            │         │
          olivia  example.org
            └── AND ──┘
-  RESULT doc:1 # Expected result
+  RESULT msg:1 # Expected result
 ```
 
 In this example, the result is exactly what we want, but there is still one
 edge case where a document contains both `olivia` and `example.org` (but not
 `olivia@example.org`). Unfortunately it’s not possible for Sonic to work around
 this case without its index being rebuilt with
-`tokenization.split_special_patterns = false` (which will be the default in
-Sonic `v2.0.0`). Here is why it would be perfect:
+`tokenization.compat_split_special_patterns = false` (which will be the default
+in Sonic `v2.0.0`). Here is why it would be perfect:
 
 ```txt
-Ingest (v1.7.4 with `tokenization.split_special_patterns = false`):
-  PUSH doc:1 "olivia@example.org"
+Ingest (v1.7.4 with `tokenization.compat_split_special_patterns = false`):
+  PUSH msg:1 "olivia@example.org"
               └────────────────┘
-  PUSH doc:2 "olivio@example.org"
+  PUSH msg:2 "olivio@example.org"
               └────────────────┘
-  PUSH doc:3 "alicia@example.org"
+  PUSH msg:3 "alicia@example.org"
               └────────────────┘
-  PUSH doc:4 "olivia@example.com"
+  PUSH msg:4 "olivia@example.com"
               └────────────────┘
-  PUSH doc:5 "olivia and olivio"
+  PUSH msg:5 "olivia and olivio"
               └────┘ └─┘ └────┘
 
 In the index: {
@@ -204,12 +204,12 @@ In the index: {
   "olivia@example.com", "olivia", "and", "olivio"
 }
 
-Search (v1.7.4 with `tokenization.split_special_patterns = false`):
+Search (v1.7.4 with `tokenization.compat_split_special_patterns = false`):
   QUERY "olivia@example.org"
          └── Special ─────┘
                 │
               Exact
                 │
          olivia@example.org
-  RESULT doc:1 # Perfect!
+  RESULT msg:1 # Perfect!
 ```

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -22,8 +22,9 @@ pub fn defaults_toml() -> &'static str {
     stemming_enabled = false
 
     [tokenization]
-    # TODO(major): Enable by default.
-    detect_special_patterns = false
+    detect_special_patterns = true
+    # TODO(major): Disable by default.
+    compat_split_special_patterns = true
 
     [search]
     query_limit_default = 10

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -77,7 +77,10 @@ fn start_sonic(
         Command::new(SONIC_BIN_PATH.as_path())
             // .args(["-c", sonic_config_path])
             .env("SONIC_CHANNEL__INET", addr.to_string())
-            .env("SONIC_SERVER__LOG_LEVEL", "WARN"),
+            .env(
+                "SONIC_SERVER__LOG_LEVEL",
+                std::env::var("LOG_LEVEL").unwrap_or("WARN".to_owned()),
+            ),
     )
     .env("SONIC_STORE__KV__PATH", data_path.join("kv"))
     .env("SONIC_STORE__FST__PATH", data_path.join("fst"))

--- a/server/tests/search_query.rs
+++ b/server/tests/search_query.rs
@@ -29,3 +29,94 @@ fn query() {
         ]
     );
 }
+
+const SPECIAL_PATTERNS_TEST_CASES: [(&str, &str); 6] = [
+    ("msg:1", "olivia@example.org"),
+    ("msg:2", "olivio@example.org"),
+    ("msg:3", "alicia@example.org"),
+    ("msg:4", "olivia@example.com"),
+    ("msg:5", "olivia and olivio"),
+    ("msg:6", "olivia works at example.org"),
+];
+
+/// Shows that `tokenization.compat_split_special_patterns = false` yields the
+/// best results.
+#[test]
+fn query_special() {
+    let ctx = start_empty(|command| {
+        command.env("SONIC_TOKENIZATION__COMPAT_SPLIT_SPECIAL_PATTERNS", "false")
+    });
+
+    let multiplexer = SonicMultiplexer::new().unwrap();
+
+    let ingest =
+        SonicChannelIngestBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+    let search =
+        SonicChannelSearchBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+
+    for (id, text) in SPECIAL_PATTERNS_TEST_CASES {
+        ingest.push("messages", "default", id, text).unwrap();
+    }
+
+    let res = search
+        .query("messages", "default", "olivia@example.org")
+        .unwrap();
+    assert_eq!(res.as_slice(), &[Box::from("msg:1")]);
+}
+
+/// Shows that the compatibility setting works, although doing worse than with
+/// `tokenization.compat_split_special_patterns = false`.
+#[test]
+fn query_special_compat() {
+    let ctx = start_empty(|command| command);
+
+    let multiplexer = SonicMultiplexer::new().unwrap();
+
+    let ingest =
+        SonicChannelIngestBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+    let search =
+        SonicChannelSearchBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+
+    for (id, text) in SPECIAL_PATTERNS_TEST_CASES {
+        ingest.push("messages", "default", id, text).unwrap();
+    }
+
+    let res = search
+        .query("messages", "default", "olivia@example.org")
+        .unwrap();
+    assert_eq!(res.as_slice(), &[Box::from("msg:6"), Box::from("msg:1")]);
+}
+
+/// Shows that disabling `tokenization.detect_special_patterns` yields unwanted
+/// results.
+#[test]
+fn query_special_disabled() {
+    let ctx =
+        start_empty(|command| command.env("SONIC_TOKENIZATION__DETECT_SPECIAL_PATTERNS", "false"));
+
+    let multiplexer = SonicMultiplexer::new().unwrap();
+
+    let ingest =
+        SonicChannelIngestBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+    let search =
+        SonicChannelSearchBlocking::connect(ctx.addr, "SecretPassword", &multiplexer).unwrap();
+
+    for (id, text) in SPECIAL_PATTERNS_TEST_CASES {
+        ingest.push("messages", "default", id, text).unwrap();
+    }
+
+    let res = search
+        .query("messages", "default", "olivia@example.org")
+        .unwrap();
+    assert_eq!(
+        res.as_slice(),
+        &[
+            Box::from("msg:6"),
+            Box::from("msg:1"),
+            Box::from("msg:5"),
+            Box::from("msg:4"),
+            Box::from("msg:3"),
+            Box::from("msg:2")
+        ]
+    );
+}


### PR DESCRIPTION
A trick to make pattern matching work without rebuilding the index.