### PR TITLE
packaging(docker): Move config file to `/etc/sonic/sonic.cfg`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ WORKDIR /usr/src/sonic
 
 COPY --from=build /app/target/release/sonic /usr/local/bin/sonic
 
-CMD [ "sonic", "-c", "/etc/sonic.cfg" ]
+CMD ["sonic"]
 
 EXPOSE 1491

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ docker pull valeriansaliou/sonic:v1.7.4
 Then, seed it a configuration file and run it (replace `/path/to/your/sonic/config.cfg` with the path to your configuration file):
 
 ```bash
-docker run -p 1491:1491 -v /path/to/your/sonic/config.cfg:/etc/sonic.cfg -v /path/to/your/sonic/store/:/var/lib/sonic/store/ valeriansaliou/sonic:v1.4.9
+docker run -p 1491:1491 -v /path/to/your/sonic/config.cfg:/etc/sonic/config.toml -v /path/to/your/sonic/store/:/var/lib/sonic/store/ valeriansaliou/sonic:v1.4.9
 ```
 
 In the configuration file, ensure that:

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -7,6 +7,8 @@
 
 use std::sync::Arc;
 
+use crate::DEFAULT_CONFIG_FILE_PATHS;
+
 pub fn defaults_toml() -> &'static str {
     r#"
     [server]
@@ -117,20 +119,33 @@ impl Config {
     }
 }
 
-pub fn read_config(path: &str) -> Config {
-    // Abort if the user specified a config path that does not exist.
-    if path != crate::DEFAULT_CONFIG_FILE_PATH && !std::path::Path::new(path).exists() {
-        panic!("Cannot find config file at {path:?}");
+pub fn read_config(custom_path: Option<&str>) -> Config {
+    if let Some(custom_path) = custom_path {
+        // Abort if the user specified a config path that does not exist.
+        if !std::path::Path::new(custom_path).exists() {
+            panic!("Cannot find config file at {custom_path:?}");
+        }
+
+        let path = std::path::absolute(custom_path).unwrap();
+        tracing::debug!("reading config file: {path:?}");
+
+        Config::parse(config::File::from(path).format(config::FileFormat::Toml))
+    } else {
+        for path in DEFAULT_CONFIG_FILE_PATHS {
+            let path = std::path::absolute(path).unwrap();
+            tracing::debug!("looking for config file at {path:?}");
+
+            if path.exists() {
+                tracing::debug!("reading config file: {path:?}");
+
+                return Config::parse(config::File::from(path).format(config::FileFormat::Toml));
+            }
+        }
+
+        tracing::debug!("no config file found in known locations, using defaults only");
+
+        Config::parse(config::File::from_str("", config::FileFormat::Toml))
     }
-
-    let path = std::path::absolute(path).unwrap();
-    tracing::debug!("reading config file: {path:?}");
-
-    Config::parse(
-        config::File::from(path)
-            .format(config::FileFormat::Toml)
-            .required(false),
-    )
 }
 
 pub struct Config {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -28,9 +28,8 @@ mod config;
 mod logger;
 mod tasker;
 
-use std::ops::Deref;
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -48,7 +47,7 @@ use crate::config::{Config, read_config};
 use crate::logger::ConfigLogger;
 
 struct AppArgs {
-    config: String,
+    config: Option<String>,
 }
 
 #[cfg(unix)]
@@ -62,9 +61,17 @@ pub static THREAD_NAME_CHANNEL_MASTER: &str = "sonic-channel-master";
 pub static THREAD_NAME_CHANNEL_CLIENT: &str = "sonic-channel-client";
 pub static THREAD_NAME_TASKER: &str = "sonic-tasker";
 
-static APP_ARGS: LazyLock<AppArgs> = LazyLock::new(make_app_args);
-
-const DEFAULT_CONFIG_FILE_PATH: &str = "./config.cfg";
+const DEFAULT_CONFIG_FILE_PATHS: [&str; 5] = [
+    // COMPAT: This has to have a high precedence, for backward compatibility
+    //   with previous default value.
+    "./config.cfg",
+    // COMPAT: This has to have a high precedence, for backward compatibility
+    //   with previous package versions.
+    "/etc/sonic.cfg",
+    "/etc/sonic/config.toml",
+    "/etc/sonic/sonic.cfg.toml",
+    "/etc/sonic/sonic.cfg",
+];
 
 fn make_app_args() -> AppArgs {
     let matches = Command::new(clap::crate_name!())
@@ -75,17 +82,13 @@ fn make_app_args() -> AppArgs {
             Arg::new("config")
                 .short('c')
                 .long("config")
-                .help("Path to configuration file")
-                .default_value(DEFAULT_CONFIG_FILE_PATH),
+                .help("Path to configuration file"),
         )
         .get_matches();
 
     // Generate owned app arguments
     AppArgs {
-        config: matches
-            .get_one::<String>("config")
-            .expect("invalid config value")
-            .to_owned(),
+        config: matches.get_one::<String>("config").cloned(),
     }
 }
 
@@ -96,7 +99,9 @@ fn main() {
             .unwrap_or(LevelFilter::DEBUG),
     );
 
-    let app_conf = read_config(&APP_ARGS.config);
+    let app_args = make_app_args();
+
+    let app_conf = read_config(app_args.config.as_deref());
 
     ConfigLogger::update(
         LevelFilter::from_str(&app_conf.server.log_level).expect("invalid log level"),
@@ -154,9 +159,6 @@ fn main() {
 }
 
 fn ensure_states() {
-    // Ensure all statics are valid (a `deref` is enough to lazily initialize them)
-    let _ = APP_ARGS.deref();
-
     // Ensure per-module states
     ensure_states_channel_statistics();
 }


### PR DESCRIPTION
Mounting `/etc/` is annoying, now one will be able to mount only `/etc/sonic/`.

I also added more search paths for the Sonic configuration file, with sensible values.

I did not touch the Debian packaging, as I was unsure whether an existing configuration would continue being used. I mean `apt` would have warned the user about appropriate actions but I didn’t want to gamble. This PR is about ergonomics of mounted paths exclusively.

Closes https://github.com/valeriansaliou/sonic/pull/325.
