### PR TITLE
fix(server): preserve escaped character after unrecognized escapes

### DIFF
--- a/server/src/channel/format.rs
+++ b/server/src/channel/format.rs
@@ -17,8 +17,7 @@ pub fn unescape(text: &str) -> String {
                 Some('n') => unescaped.push('\n'),
                 Some('\"') => unescaped.push('\"'),
                 Some(c) => {
-                    // Preserve unknown escape sequences verbatim instead of
-                    // silently dropping the escaped character.
+                    // Preserve unknown escape sequences verbatim.
                     unescaped.push(character);
                     unescaped.push(c);
                 }

--- a/server/src/channel/format.rs
+++ b/server/src/channel/format.rs
@@ -16,7 +16,13 @@ pub fn unescape(text: &str) -> String {
             match characters.next() {
                 Some('n') => unescaped.push('\n'),
                 Some('\"') => unescaped.push('\"'),
-                _ => unescaped.push(character),
+                Some(c) => {
+                    // Preserve unknown escape sequences verbatim instead of
+                    // silently dropping the escaped character.
+                    unescaped.push(character);
+                    unescaped.push(c);
+                }
+                None => unescaped.push(character),
             };
         } else {
             unescaped.push(character);
@@ -39,8 +45,12 @@ mod tests {
         );
         assert_eq!(
             unescape(r#"look at \\\\"\\\" me i'm \\"\"trying to hack you\""#),
-            r#"look at \\"\" me i'm \""trying to hack you""#.to_string()
+            r#"look at \\\\"\\" me i'm \\"""trying to hack you""#.to_string()
         );
+
+        // Regression: unknown escape sequences must pass through unchanged.
+        assert_eq!(unescape(r"C:\Windows\System32"), r"C:\Windows\System32".to_string());
+        assert_eq!(unescape("trailing \\"), "trailing \\".to_string());
     }
 }
 


### PR DESCRIPTION
## Summary

As confirmed in #397, `unescape()` silently dropped the character following any backslash sequence other than `\n` and `\"` (e.g. `path\C:\Users` became `path\:\<LF>otes`). This PR makes unknown escapes pass through verbatim, per the direction discussed in the issue.

## Changes

- `server/src/channel/format.rs`: the catch-all match arm now binds the lookahead character and pushes both it and the backslash; a trailing lone backslash is still preserved via the new explicit `None` arm.
- Updated `it_unescapes_command_text`: its expected value had encoded the old dropping behavior (backslash runs were halved); the expectation now reflects passthrough semantics.
- Added regression tests: unknown escapes survive round-trip (`C:\Windows\System32`) and a trailing lone backslash is kept.

## Compatibility note

Per the discussion in #397 this changes output for inputs that previously lost characters - strictly a data-preservation improvement, but technically behavior-changing, so shipping with the planned minor-release warning sounds right.

Fixes #397